### PR TITLE
update at a glance to be much smarter

### DIFF
--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -201,7 +201,29 @@
   // ctx.readFile is an async function to read any file from your plugin folder
   // ctx.signProxyUrl(url) returns a signed /api/proxy/image URL for any external image
   // ctx.fetch(url, init?) is a proxy-aware fetch, respects your outgoing proxy settings
+  // ctx.createCache(defaultTtlMs) returns an in-memory TTL cache { get, set, clear }
 }</code></pre>
+          <h3>TTL cache (<code>createCache</code>)</h3>
+          <p>
+            Both <code>init(ctx)</code> and slot <code>execute(query, context)</code>
+            receive <strong><code>createCache</code></strong>: a factory compatible with
+            the built-in server helper. Call
+            <code>ctx.createCache&lt;T&gt;(defaultTtlMs)</code> (or
+            <code>context.createCache&lt;T&gt;(defaultTtlMs)</code> in slots) to get an
+            object with <code>get(key)</code>, <code>set(key, value, ttlMs?)</code>, and
+            <code>clear()</code>. Keys are strings; values are typed by your generic
+            <code>T</code>. Entries expire automatically after the TTL (milliseconds).
+          </p>
+          <p>
+            Built-in and third-party code paths share this API: typical usage is to
+            call <code>createCache</code> once in <code>init</code>, keep the returned
+            cache on a module-level variable, and reuse <code>get</code> /
+            <code>set</code> from <code>execute</code> (for example for fetched page
+            excerpts). Prefer <strong>always</strong> using
+            <code>ctx.createCache</code> / <code>context.createCache</code> rather than
+            importing cache helpers from server internals so plugins behave the same in
+            every environment.
+          </p>
           <p>
             Store <code>ctx.fetch</code> during <code>init</code> if your plugin
             makes outgoing HTTP requests outside of <code>execute()</code>, for
@@ -400,11 +422,14 @@
               <strong>execute(query, context)</strong> (async): Return an object
               with an optional <code>title</code> string and an
               <code>html</code> string. If you return an empty string for the
-              html, nothing will show up. The <code>context</code> contains the
-              <code>clientIp</code>, an array of <code>results</code>, and
-              <code>signProxyUrl(url)</code> for proxying external images. Note
-              that the results array is only populated if you set
-              <code>waitForResults: true</code> on your plugin.
+              html, nothing will show up. The <code>context</code> includes
+              <code>clientIp</code>; <code>results</code> (only when
+              <code>waitForResults: true</code>); proxy-aware
+              <code>fetch(url, init?)</code>; <code>signProxyUrl(url)</code> for
+              external images; and <code>createCache(defaultTtlMs)</code> for the same
+              TTL cache factory as in <code>init(ctx)</code>. Note that the results
+              array is only populated if you set <code>waitForResults: true</code> on
+              your plugin.
             </li>
           </ul>
           <p>

--- a/src/server/extensions/commands/builtins/ai-summary/index.ts
+++ b/src/server/extensions/commands/builtins/ai-summary/index.ts
@@ -1,9 +1,13 @@
+import { createHash } from "node:crypto";
 import {
   SlotPanelPosition,
   TranslateFunction,
+  type PluginContext,
+  type ScoredResult,
   type SettingField,
   type SlotPlugin,
 } from "../../../../types";
+import { SHORT_TTL_MS, type TtlCache } from "../../../../utils/cache";
 import { logger } from "../../../../utils/logger";
 import { asString, getSettings } from "../../../../utils/plugin-settings";
 
@@ -111,6 +115,17 @@ function escapeHtml(s: string): string {
 const DEFAULT_SYSTEM_PROMPT =
   "You are a helpful assistant that summarises web search results. Write a concise 2–3 sentence summary answering the query based on the provided snippets. Do not invent facts. Do not include citations.";
 
+let _summaryCache!: TtlCache<string>;
+
+function _summaryCacheKey(query: string, results: ScoredResult[]): string {
+  const fp = results
+    .slice(0, 6)
+    .map((r) => `${r.url}\n${r.snippet}`)
+    .join("\n\n");
+  const hash = createHash("sha256").update(fp).digest("hex").slice(0, 24);
+  return `${query.trim().toLowerCase()}|${hash}`;
+}
+
 async function chatComplete(
   settings: AISummarySettings,
   messages: OpenAIMessage[],
@@ -201,6 +216,10 @@ const aiSummarySlot: SlotPlugin = {
 
   t: TranslateFunction,
 
+  init(ctx: PluginContext): void {
+    _summaryCache = ctx.createCache<string>(SHORT_TTL_MS);
+  },
+
   async trigger(): Promise<boolean> {
     const settings = await getAISummarySettings();
     return !!settings.baseUrl && !!settings.model;
@@ -208,8 +227,14 @@ const aiSummarySlot: SlotPlugin = {
   async execute(query, context): Promise<{ title?: string; html: string }> {
     const results = context?.results ?? [];
     if (results.length === 0) return { html: "" };
-    const summary = await generateAISummary(query, results);
-    if (!summary) return { html: "" };
+    const key = _summaryCacheKey(query, results);
+    let summary = _summaryCache.get(key);
+    if (summary === null) {
+      const generated = await generateAISummary(query, results);
+      if (!generated) return { html: "" };
+      _summaryCache.set(key, generated);
+      summary = generated;
+    }
     return {
       html:
         '<div class="glance-ai">' +

--- a/src/server/extensions/commands/builtins/at-a-glance/index.ts
+++ b/src/server/extensions/commands/builtins/at-a-glance/index.ts
@@ -1,19 +1,226 @@
+import * as cheerio from "cheerio";
 import {
   SlotPanelPosition,
   TranslateFunction,
+  type PluginContext,
+  type SettingField,
+  type ScoredResult,
   type SlotPlugin,
 } from "../../../../types";
+import {
+  asString,
+  getSettings,
+  isDisabled,
+} from "../../../../utils/plugin-settings";
+import type { TtlCache } from "../../../../utils/cache";
+import { looksLikeProse, stripSnippetPrefix } from "../../../../utils/text";
+import { getRandomUserAgent } from "../../../../utils/user-agents";
 
-function escapeHtml(s: string): string {
-  return s
+const SETTINGS_ID = "slot-at-a-glance";
+const WIKIPEDIA_SETTINGS_ID = "slot-wikipedia";
+const WIKIPEDIA_HOSTNAME = "wikipedia.org";
+
+let _extractCache!: TtlCache<string>;
+
+const _escapeHtml = (s: string): string =>
+  s
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+
+const _isWikipediaUrl = (url: string): boolean => {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === WIKIPEDIA_HOSTNAME || host.endsWith(`.${WIKIPEDIA_HOSTNAME}`);
+  } catch {
+    return false;
+  }
+};
+
+const _scoreSnippet = (snippet: string, queryTerms: string[]): number => {
+  if (!snippet || snippet.length < 20) return 0;
+  if (!looksLikeProse(snippet)) return 0;
+  const lower = snippet.toLowerCase();
+  const termHits = queryTerms.filter((t) => lower.includes(t)).length;
+  const densityBonus = termHits / Math.max(queryTerms.length, 1);
+  const lengthScore = Math.min(snippet.length / 200, 1);
+  return lengthScore * (1 + densityBonus);
+};
+
+const _pickBestResult = (
+  results: ScoredResult[],
+  excludeWikipedia: boolean,
+  queryTerms: string[],
+): ScoredResult | null => {
+  const candidates = excludeWikipedia
+    ? results.filter((r) => !_isWikipediaUrl(r.url))
+    : results;
+  if (candidates.length === 0) return null;
+  return candidates.reduce((best, r) =>
+    _scoreSnippet(r.snippet, queryTerms) > _scoreSnippet(best.snippet, queryTerms)
+      ? r
+      : best,
+  );
+};
+
+type ExcerptMode = "strict" | "full";
+
+const _pushExtractParagraph = (
+  found: string[],
+  text: string,
+  perParaBudget: number,
+): void => {
+  found.push(
+    text.length > perParaBudget ? `${text.slice(0, perParaBudget)}…` : text,
+  );
+};
+
+const _finalizeExtractJoin = (found: string[], maxLength: number): string => {
+  let joined = found.join("\n\n");
+  if (joined.length > maxLength) {
+    joined = `${joined.slice(0, maxLength)}…`;
+  }
+  return joined;
+};
+
+const _extractFromHtml = (
+  html: string,
+  queryTerms: string[],
+  maxLength: number,
+  maxParagraphs: number,
+  excerptMode: ExcerptMode,
+): string | null => {
+  const sepCost = Math.max(0, maxParagraphs - 1) * 2;
+  const perParaBudget = Math.max(
+    1,
+    Math.floor((maxLength - sepCost) / maxParagraphs),
+  );
+
+  const $ = cheerio.load(html);
+  $("script, style, nav, header, footer, aside").remove();
+  const root = $("article, main, [role='main']").first();
+  const scope = root.length ? root : $("body");
+  const found: string[] = [];
+
+  if (excerptMode === "strict") {
+    scope.find("p").each((_i, el) => {
+      if (found.length >= maxParagraphs) return false;
+      const text = $(el).text().replace(/\s+/g, " ").trim();
+      if (text.length < 60) return;
+      if (!looksLikeProse(text)) return;
+      const lower = text.toLowerCase();
+      if (queryTerms.some((t) => lower.includes(t))) {
+        _pushExtractParagraph(found, text, perParaBudget);
+      }
+    });
+    return found.length > 0 ? _finalizeExtractJoin(found, maxLength) : null;
+  }
+
+  let anchored = false;
+  scope.find("p").each((_i, el) => {
+    if (found.length >= maxParagraphs) return false;
+    const text = $(el).text().replace(/\s+/g, " ").trim();
+    if (text.length < 60) return;
+    if (!looksLikeProse(text)) return;
+    const lower = text.toLowerCase();
+    if (!anchored) {
+      if (queryTerms.some((t) => lower.includes(t))) {
+        _pushExtractParagraph(found, text, perParaBudget);
+        anchored = true;
+      }
+      return;
+    }
+    _pushExtractParagraph(found, text, perParaBudget);
+  });
+  return found.length > 0 ? _finalizeExtractJoin(found, maxLength) : null;
+};
+
+const _extractCacheKey = (
+  url: string,
+  excerptMode: ExcerptMode,
+  maxLength: number,
+  maxParagraphs: number,
+  queryTerms: string[],
+): string => {
+  const termsKey = [...queryTerms].sort().join("\x1f");
+  return `${url}\x1e${excerptMode}\x1e${maxLength}\x1e${maxParagraphs}\x1e${termsKey}`;
+};
+
+const _fetchExtract = async (
+  url: string,
+  queryTerms: string[],
+  maxLength: number,
+  maxParagraphs: number,
+  excerptMode: ExcerptMode,
+  timeoutMs: number,
+  fetchFn: (url: string, init?: RequestInit) => Promise<Response>,
+): Promise<string | null> => {
+  const cacheKey = _extractCacheKey(
+    url,
+    excerptMode,
+    maxLength,
+    maxParagraphs,
+    queryTerms,
+  );
+  const cached = _extractCache.get(cacheKey);
+  if (cached !== null) return cached;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetchFn(url, {
+      signal: controller.signal,
+      headers: { "User-Agent": getRandomUserAgent(), Accept: "text/html" },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const ct = res.headers.get("content-type") ?? "";
+    if (!ct.includes("text/html")) return null;
+    const html = await res.text();
+    const extracted = _extractFromHtml(
+      html,
+      queryTerms,
+      maxLength,
+      maxParagraphs,
+      excerptMode,
+    );
+    if (extracted) _extractCache.set(cacheKey, extracted);
+    return extracted;
+  } catch {
+    clearTimeout(timer);
+    return null;
+  }
+};
+
+const _loadSettings = async () => {
+  const stored = await getSettings(SETTINGS_ID);
+  const rawLength = parseInt(asString(stored["snippetLength"]), 10);
+  const rawTimeout = parseFloat(asString(stored["fetchTimeoutSeconds"]) || "3");
+  const rawParagraphs = parseInt(asString(stored["paragraphs"]) || "1", 10);
+  const rawMode = asString(stored["excerptMode"]).toLowerCase();
+  const excerptMode: ExcerptMode = rawMode === "strict" ? "strict" : "full";
+
+  return {
+    maxLength:
+      Number.isFinite(rawLength) && rawLength > 0
+        ? Math.max(100, rawLength)
+        : 400,
+    fetchContent: asString(stored["fetchContent"]) !== "false",
+    fetchTimeoutMs: Number.isFinite(rawTimeout)
+      ? Math.max(1, Math.min(rawTimeout, 30)) * 1000
+      : 3_000,
+    maxParagraphs: Number.isFinite(rawParagraphs)
+      ? Math.max(1, Math.min(rawParagraphs, 5))
+      : 1,
+    excerptMode,
+  };
+};
 
 const atAGlanceSlot: SlotPlugin = {
   id: "at-a-glance",
+  settingsId: SETTINGS_ID,
   name: "At a Glance",
   get description(): string {
     return this.t!("at-a-glance.description");
@@ -23,25 +230,108 @@ const atAGlanceSlot: SlotPlugin = {
 
   t: TranslateFunction,
 
+  init(ctx: PluginContext): void {
+    _extractCache = ctx.createCache<string>(60 * 60 * 1000);
+  },
+
   trigger(): boolean {
     return true;
   },
 
-  async execute(_query: string, context): Promise<{ html: string }> {
+  settingsSchema: [
+    {
+      key: "snippetLength",
+      label: "Snippet length",
+      type: "number",
+      default: "400",
+      placeholder: "400",
+      description:
+        "Maximum characters for the combined snippet (paragraphs share this budget). At least 100; otherwise uses your number, or 400 if unset or invalid.",
+    },
+    {
+      key: "paragraphs",
+      label: "Paragraphs",
+      type: "select",
+      options: ["1", "2", "3", "4", "5"],
+      default: "1",
+      description:
+        "Number of paragraphs to extract from the page. More gives more context but takes more space.",
+    },
+    {
+      key: "excerptMode",
+      label: "Excerpt mode",
+      type: "select",
+      options: ["full", "strict"],
+      default: "full",
+      description:
+        "Full: first paragraph must match the query, following won't need to. Strict: every paragraph must match the query.",
+    },
+    {
+      key: "fetchContent",
+      label: "Fetch page content",
+      type: "toggle",
+      default: "true",
+      description:
+        "Fetch the actual page for richer content. Disable to use search snippets only (faster).",
+    },
+    {
+      key: "fetchTimeoutSeconds",
+      label: "Fetch timeout (seconds)",
+      type: "number",
+      default: "3",
+      placeholder: "3",
+      description:
+        "How long to wait for the page fetch before falling back to the search snippet.",
+      advanced: true,
+    },
+  ] as SettingField[],
+
+  async execute(query: string, context): Promise<{ html: string }> {
     const results = context?.results ?? [];
-    const top = results.length > 0 && results[0].snippet ? results[0] : null;
-    if (!top) return { html: "" };
+    if (results.length === 0) return { html: "" };
+
+    const [settings, wikipediaDisabled] = await Promise.all([
+      _loadSettings(),
+      isDisabled(WIKIPEDIA_SETTINGS_ID),
+    ]);
+
+    const queryTerms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const best = _pickBestResult(results, !wikipediaDisabled, queryTerms);
+    if (!best) return { html: "" };
+
+    let snippet = looksLikeProse(best.snippet)
+      ? stripSnippetPrefix(best.snippet)
+      : "";
+
+    if (settings.fetchContent && context?.fetch) {
+      const extracted = await _fetchExtract(
+        best.url,
+        queryTerms,
+        settings.maxLength,
+        settings.maxParagraphs,
+        settings.excerptMode,
+        settings.fetchTimeoutMs,
+        context.fetch,
+      );
+      if (extracted) snippet = extracted;
+    }
+
+    if (!snippet) return { html: "" };
+
+    if (snippet.length > settings.maxLength) {
+      snippet = `${snippet.slice(0, settings.maxLength)}…`;
+    }
 
     const foundOn = this.t!("at-a-glance.found-on", {
-      sources_text: top.sources.join(", "),
+      sources_text: best.sources.join(", "),
     });
 
     return {
       html:
         '<div class="glance-box">' +
-        `<div class="glance-snippet">${escapeHtml(top.snippet)}</div>` +
-        `<a class="glance-link" href="${escapeHtml(top.url)}" target="_blank">${escapeHtml(top.title)}</a>` +
-        `<div class="glance-sources">${escapeHtml(foundOn)}</div>` +
+        `<div class="glance-snippet">${_escapeHtml(snippet)}</div>` +
+        `<a class="glance-link" href="${_escapeHtml(best.url)}" target="_blank">${_escapeHtml(best.title)}</a>` +
+        `<div class="glance-sources">${_escapeHtml(foundOn)}</div>` +
         "</div>",
     };
   },

--- a/src/server/extensions/commands/builtins/wikipedia/index.ts
+++ b/src/server/extensions/commands/builtins/wikipedia/index.ts
@@ -4,6 +4,7 @@ import {
   type PluginContext,
   type SlotPlugin,
 } from "../../../../types";
+import type { TtlCache } from "../../../../utils/cache";
 
 const TIMEOUT_MS = 5_000;
 const USER_AGENT = "degoog/1.0 (+https://github.com/degoog-org/degoog)";
@@ -27,10 +28,7 @@ interface WikiPage {
 
 let _template = "";
 
-let _cache: { query: string | null; page: WikiPage | null } = {
-  query: null,
-  page: null,
-};
+let _wikiCache!: TtlCache<WikiPage>;
 
 async function _fetchWikipedia(query: string): Promise<WikiPage | null> {
   const controller = new AbortController();
@@ -92,22 +90,35 @@ const wikipediaSlot: SlotPlugin = {
 
   init(ctx: PluginContext): void {
     _template = ctx.template;
+    _wikiCache = ctx.createCache<WikiPage>(60 * 60 * 1000);
   },
 
   async trigger(query: string): Promise<boolean> {
     const q = query.trim();
     if (q.length < 2 || q.length > 100) return false;
-    const page = await _fetchWikipedia(q);
-    _cache = { query: q, page };
-    return page !== null;
+    const key = q.toLowerCase();
+    const page = _wikiCache.get(key);
+    if (page === null) {
+      const fetched = await _fetchWikipedia(q);
+      if (fetched) {
+        _wikiCache.set(key, fetched);
+        return true;
+      }
+      return false;
+    }
+    return true;
   },
 
   async execute(query: string): Promise<{ title?: string; html: string }> {
     const q = query.trim();
-    let page = _cache.query === q ? _cache.page : null;
-    if (!page) {
-      page = await _fetchWikipedia(q);
-      _cache = { query: q, page };
+    const key = q.toLowerCase();
+    let page = _wikiCache.get(key);
+    if (page === null) {
+      const fetched = await _fetchWikipedia(q);
+      if (fetched) {
+        _wikiCache.set(key, fetched);
+        page = fetched;
+      }
     }
     if (!page) return { html: "" };
 
@@ -123,7 +134,7 @@ const wikipediaSlot: SlotPlugin = {
 
     const html = _template.replace(
       /\{\{(\w+)\}\}/g,
-      (_, key: string) => sanitizePage[key] ?? "",
+      (_, k: string) => sanitizePage[k] ?? "",
     );
 
     return { title: page.title, html };

--- a/src/server/routes/slots.ts
+++ b/src/server/routes/slots.ts
@@ -90,7 +90,7 @@ router.post("/api/slots/glance", async (c) => {
         position: plugin.position,
         gridSize: plugin.gridSize,
       });
-    } catch {}
+    } catch { }
   }
   return c.json({ panels });
 });

--- a/src/server/routes/slots.ts
+++ b/src/server/routes/slots.ts
@@ -6,6 +6,7 @@ import {
   SlotPanelResult,
   SlotPluginContext,
 } from "../types";
+import { createCache } from "../utils/cache";
 import { getLocale } from "../utils/hono";
 import { logger } from "../utils/logger";
 import { outgoingFetch } from "../utils/outgoing";
@@ -70,6 +71,7 @@ router.post("/api/slots/glance", async (c) => {
         results: body.results,
         fetch: outgoingFetch as SlotPluginContext["fetch"],
         signProxyUrl: buildSignedProxyUrl,
+        createCache,
       };
       const t0 = performance.now();
       const out = await plugin.execute(body.query!.trim(), context);

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -19,6 +19,7 @@ import type {
 } from "./types";
 import { extractImageUrl } from "./utils/extract-image";
 import { outgoingFetch, parseOutgoingTransport } from "./utils/outgoing";
+import { stripHtml } from "./utils/text";
 import { asString, getSettings } from "./utils/plugin-settings";
 import { buildSignedProxyUrl } from "./utils/proxy-sign";
 
@@ -100,8 +101,9 @@ const _mergeIntoMap = (
       if (!existing.sources.includes(r.source)) {
         existing.sources.push(r.source);
       }
-      if (r.snippet.length > existing.snippet.length) {
-        existing.snippet = r.snippet;
+      const cleanSnippet = stripHtml(r.snippet);
+      if (cleanSnippet.length > existing.snippet.length) {
+        existing.snippet = cleanSnippet;
       }
       if (r.thumbnail && !existing.thumbnail) {
         existing.thumbnail = r.thumbnail;
@@ -110,6 +112,8 @@ const _mergeIntoMap = (
     } else {
       urlMap.set(normalized, {
         ...r,
+        title: stripHtml(r.title),
+        snippet: stripHtml(r.snippet),
         url: normalized,
         score: positionScore,
         sources: [r.source],
@@ -304,10 +308,10 @@ export const search = async (
     type === "web"
       ? await getActiveWebEngines(config)
       : getEnginesForSearchType(type, config).map((e) => ({
-          id: e.id,
-          instance: e.instance,
-          score: 1,
-        }));
+        id: e.id,
+        instance: e.instance,
+        score: 1,
+      }));
 
   if (rawActiveEngines.length === 0) {
     return {

--- a/src/server/types/extension.ts
+++ b/src/server/types/extension.ts
@@ -1,3 +1,4 @@
+import type { CreateCache } from "../utils/cache";
 import type {
   SearchResult,
   ScoredResult,
@@ -80,6 +81,7 @@ export interface PluginContext {
   readFile: (filename: string) => Promise<string>;
   signProxyUrl: (url: string) => string;
   fetch?: (url: string, init?: RequestInit) => Promise<Response>;
+  createCache: CreateCache;
 }
 
 export interface SearchEngine {
@@ -120,6 +122,7 @@ export interface SlotPluginContext {
   results?: ScoredResult[];
   fetch?: (url: string, init?: RequestInit) => Promise<Response>;
   signProxyUrl?: (url: string) => string;
+  createCache: CreateCache;
 }
 
 export interface SlotPlugin {

--- a/src/server/utils/cache.ts
+++ b/src/server/utils/cache.ts
@@ -1,33 +1,45 @@
 import type { SearchResponse } from "../types";
 
-const TTL_MS = 12 * 60 * 60 * 1000;
-const SHORT_TTL_MS = 2 * 60 * 1000;
-const NEWS_TTL_MS = 30 * 60 * 1000;
-const store = new Map<string, { value: SearchResponse; expiresAt: number }>();
+export const TTL_MS = 12 * 60 * 60 * 1000;
+export const SHORT_TTL_MS = 2 * 60 * 1000;
+export const NEWS_TTL_MS = 30 * 60 * 1000;
 
-export function get(key: string): SearchResponse | null {
-  const entry = store.get(key);
-  if (!entry || Date.now() > entry.expiresAt) {
-    if (entry) store.delete(key);
-    return null;
-  }
-  return entry.value;
+export type TtlCache<T> = {
+  get(key: string): T | null;
+  set(key: string, value: T, ttlMs?: number): void;
+  clear(): void;
+};
+
+export function createCache<T>(defaultTtlMs: number): TtlCache<T> {
+  const store = new Map<string, { value: T; expiresAt: number }>();
+  return {
+    get(key: string): T | null {
+      const entry = store.get(key);
+      if (!entry) return null;
+      if (Date.now() > entry.expiresAt) {
+        store.delete(key);
+        return null;
+      }
+      return entry.value;
+    },
+    set(key: string, value: T, ttlMs: number = defaultTtlMs): void {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+    },
+    clear(): void {
+      store.clear();
+    },
+  };
 }
 
-export function set(
-  key: string,
-  value: SearchResponse,
-  ttlMs: number = TTL_MS,
-): void {
-  store.set(key, { value, expiresAt: Date.now() + ttlMs });
-}
+export type CreateCache = typeof createCache;
+
+const _searchCache = createCache<SearchResponse>(TTL_MS);
+
+export const get = (key: string): SearchResponse | null => _searchCache.get(key);
+export const set = (key: string, value: SearchResponse, ttlMs: number = TTL_MS): void =>
+  _searchCache.set(key, value, ttlMs);
+export const clear = (): void => _searchCache.clear();
 
 export function hasFailedEngines(response: SearchResponse): boolean {
   return response.engineTimings.some((et) => et.resultCount === 0);
-}
-
-export { TTL_MS, SHORT_TTL_MS, NEWS_TTL_MS };
-
-export function clear(): void {
-  store.clear();
 }

--- a/src/server/utils/plugin-assets.ts
+++ b/src/server/utils/plugin-assets.ts
@@ -68,6 +68,7 @@ export function getScriptFolderSource(
 
 import { join } from "path";
 import type { PluginContext, SettingField } from "../types";
+import { createCache } from "./cache";
 import { outgoingFetch } from "./outgoing";
 import { buildSignedProxyUrl } from "./proxy-sign";
 import {
@@ -117,6 +118,7 @@ export async function initPlugin(
         readFile(join(entryPath, filename), "utf-8"),
       signProxyUrl: buildSignedProxyUrl,
       fetch: outgoingFetch as PluginContext["fetch"],
+      createCache,
     };
     await Promise.resolve(plugin.init(ctx));
   }

--- a/src/server/utils/search.ts
+++ b/src/server/utils/search.ts
@@ -204,7 +204,7 @@ export async function runSlotPlugins(
         position: effectivePosition,
         gridSize: plugin.gridSize,
       });
-    } catch {}
+    } catch { }
   }
   return panels;
 }

--- a/src/server/utils/search.ts
+++ b/src/server/utils/search.ts
@@ -11,6 +11,7 @@ import {
   SlotPluginContext,
   TimeFilter,
 } from "../types";
+import { createCache } from "./cache";
 import { logger } from "./logger";
 import { outgoingFetch } from "./outgoing";
 import { asString, getSettings, isDisabled } from "./plugin-settings";
@@ -184,6 +185,7 @@ export async function runSlotPlugins(
         results: plugin.waitForResults ? results : undefined,
         fetch: outgoingFetch as SlotPluginContext["fetch"],
         signProxyUrl: buildSignedProxyUrl,
+        createCache,
       };
       const t0 = performance.now();
       const out = await plugin.execute(query, context);

--- a/src/server/utils/text.ts
+++ b/src/server/utils/text.ts
@@ -1,0 +1,20 @@
+export const stripHtml = (text: string): string =>
+  text.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+
+const _DATE_PREFIX =
+  /^(?:\d{1,2}\s+)?(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},?\s+\d{4}|\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}\/\d{4}|\d+\s+(?:second|minute|hour|day|week|month|year)s?\s+ago/i;
+
+export const stripSnippetPrefix = (text: string): string => {
+  const stripped = text.replace(
+    new RegExp(`^(?:${_DATE_PREFIX.source})\\s*[-–—·]\\s*`, "i"),
+    "",
+  );
+  return stripped || text;
+};
+
+export const looksLikeProse = (text: string): boolean => {
+  if (/\{[^}]{0,500}\}/.test(text)) return false;
+  const specialChars = (text.match(/[^a-zA-Z0-9\s.,!?'"()\-–—]/g) ?? []).length;
+  const words = text.split(/\s+/).filter(Boolean);
+  return specialChars / text.length < 0.10 && words.length >= 8;
+};

--- a/src/styles/components/_settings.scss
+++ b/src/styles/components/_settings.scss
@@ -10,7 +10,7 @@
   min-height: 100vh;
 
   @media (min-width: 768px) {
-    max-width: 60rem;
+    max-width: 70rem;
   }
 }
 
@@ -61,7 +61,7 @@
   margin-bottom: $space-6;
 
   @media (min-width: 768px) {
-    width: 11.25rem;
+    width: 14rem;
     flex-shrink: 0;
     align-self: flex-start;
     position: sticky;


### PR DESCRIPTION
This pull request makes the at a glance plugin a little smarter by

- Not default to the first result, tries to get something meaningful that matches the search query
- If the wikipedia plugin is enabled SKIPS wikipedia
- By default actually scrapes the selected result for a specific paragraph that matches the search query. This can be disabled by configurations
- Allows user to set max length of the snippet of text and other few settings.