### PR TITLE
Add ability for GIFs to play in the image tab

### DIFF
--- a/src/client/constants.ts
+++ b/src/client/constants.ts
@@ -7,6 +7,7 @@ export const OPEN_IN_NEW_TAB_KEY = "open_in_new_tab";
 export const DISPLAY_ENGINE_PERFORMANCE = "display_engine_performance";
 export const DISPLAY_SEARCH_SUGGESTIONS = "display_search_suggestions";
 export const POST_METHOD_ENABLED = "post_method_enabled";
+export const INLINE_GIF_PLAYBACK = "inline_gif_playback";
 export const PER_PAGE = 10;
 export const MAX_PAGE = 10;
 export const BUILTIN_SEARCH_TYPES = new Set([

--- a/src/client/modules/init.ts
+++ b/src/client/modules/init.ts
@@ -2,6 +2,7 @@ import { initLuckyAnimation } from "../animations/lucky-animation";
 import {
   DISPLAY_ENGINE_PERFORMANCE,
   DISPLAY_SEARCH_SUGGESTIONS,
+  INLINE_GIF_PLAYBACK,
   OPEN_IN_NEW_TAB_KEY,
   POST_METHOD_ENABLED,
 } from "../constants";
@@ -162,6 +163,9 @@ export function init(): void {
   });
   void idbGet<boolean>(POST_METHOD_ENABLED).then((v) => {
     if (v !== null) state.postMethodEnabled = v;
+  });
+  void idbGet<boolean>(INLINE_GIF_PLAYBACK).then((v) => {
+    if (v !== null) state.inlineGifPlayback = v;
   });
 
   document.body.addEventListener("click", (e) => {

--- a/src/client/modules/media/media.ts
+++ b/src/client/modules/media/media.ts
@@ -3,11 +3,7 @@ import { getBase } from "../../utils/base-url";
 import type { ScoredResult } from "../../types";
 import { cleanHostname, escapeHtml } from "../../utils/dom";
 import { getEngines } from "../../utils/engines";
-import {
-  buildSearchBody,
-  buildSearchUrl,
-  proxyImageUrl,
-} from "../../utils/url";
+import { buildSearchBody, buildSearchUrl } from "../../utils/url";
 import { openLightbox } from "./lightbox";
 import { searchAuthHeaders, appendSearchAuthParams } from "../../utils/request";
 
@@ -156,7 +152,7 @@ export function openMediaPreview(
 
   if (img) {
     img.style.display = "";
-    img.src = proxyImageUrl(previewSrc) || "";
+    img.src = previewSrc || "";
     img.style.cursor = "zoom-in";
     img.onclick = () => {
       const src = img.src;
@@ -174,7 +170,7 @@ export function openMediaPreview(
     if (isVideo) {
       actions = `<a class="btn btn--primary degoog-btn degoog-btn--primary media-preview-visit" href="${escapeHtml(item.url)}"${target}>Watch video</a>`;
     } else {
-      const downloadUrl = previewSrc ? proxyImageUrl(previewSrc) : "";
+      const downloadUrl = previewSrc || "";
       const downloadFilename = (() => {
         try {
           const p = new URL(previewSrc).pathname;

--- a/src/client/modules/renderer/render-media.ts
+++ b/src/client/modules/renderer/render-media.ts
@@ -1,6 +1,5 @@
 import { state } from "../../state";
 import { escapeHtml, cleanHostname } from "../../utils/dom";
-import { isGifImageUrl, proxyImageUrl } from "../../utils/url";
 import { openMediaPreview, registerAppendMediaCards } from "../media/media";
 import { setupRetryLinks } from "./render-sidebar";
 import { renderTemplate } from "../../utils/template";
@@ -55,16 +54,16 @@ function _handleResize(): void {
 let _resizeListenerAdded = false;
 
 const _imageCardUrl = (r: ScoredResult): string => {
-  const thumbnail = proxyImageUrl(r.thumbnail || "");
-  if (!state.inlineGifPlayback) return thumbnail;
-  if (r.imageUrl && isGifImageUrl(r.imageUrl)) return proxyImageUrl(r.imageUrl);
-  return thumbnail;
+  const thumbnail = r.thumbnail || "";
+  if (!state.inlineGifPlayback || !r.isGif || !r.imageUrl) return thumbnail;
+  return r.imageUrl;
 };
 
 const _buildMediaContext = (r: ScoredResult): Record<string, unknown> => ({
   title: r.title,
   url: r.url,
   thumbnail_url: _imageCardUrl(r),
+  fallback_url: r.thumbnail || "",
   hostname: cleanHostname(r.url),
   duration: r.duration || "",
   sources: r.sources,

--- a/src/client/modules/renderer/render-media.ts
+++ b/src/client/modules/renderer/render-media.ts
@@ -1,6 +1,6 @@
 import { state } from "../../state";
 import { escapeHtml, cleanHostname } from "../../utils/dom";
-import { proxyImageUrl } from "../../utils/url";
+import { isGifImageUrl, proxyImageUrl } from "../../utils/url";
 import { openMediaPreview, registerAppendMediaCards } from "../media/media";
 import { setupRetryLinks } from "./render-sidebar";
 import { renderTemplate } from "../../utils/template";
@@ -54,10 +54,17 @@ function _handleResize(): void {
 
 let _resizeListenerAdded = false;
 
+const _imageCardUrl = (r: ScoredResult): string => {
+  const thumbnail = proxyImageUrl(r.thumbnail || "");
+  if (!state.inlineGifPlayback) return thumbnail;
+  if (r.imageUrl && isGifImageUrl(r.imageUrl)) return proxyImageUrl(r.imageUrl);
+  return thumbnail;
+};
+
 const _buildMediaContext = (r: ScoredResult): Record<string, unknown> => ({
   title: r.title,
   url: r.url,
-  thumbnail_url: proxyImageUrl(r.thumbnail || ""),
+  thumbnail_url: _imageCardUrl(r),
   hostname: cleanHostname(r.url),
   duration: r.duration || "",
   sources: r.sources,

--- a/src/client/modules/renderer/render.ts
+++ b/src/client/modules/renderer/render.ts
@@ -6,7 +6,7 @@ import { buildPaginationHtml } from "../../utils/pagination";
 import { goToPage } from "../../utils/search-actions";
 import { renderTemplate } from "../../utils/template";
 import { attachFaviconFallback } from "../../utils/favicon";
-import { faviconHostname, faviconUrl, proxyImageUrl } from "../../utils/url";
+import { faviconHostname, faviconUrl } from "../../utils/url";
 import { destroyMediaObserver, setupMediaObserver } from "../media/media";
 import { renderImageGrid } from "./render-media";
 
@@ -46,7 +46,7 @@ export const buildResultContext = (
     snippet: r.snippet,
     favicon_url: faviconUrl(r.url),
     favicon_host: faviconHostname(r.url),
-    thumbnail_url: r.thumbnail ? proxyImageUrl(r.thumbnail) : "",
+    thumbnail_url: r.thumbnail || "",
     sources: r.sources,
     duration: r.duration || "",
     is_video: state.currentType === "videos" || !!r.duration,

--- a/src/client/settings/general-tab.ts
+++ b/src/client/settings/general-tab.ts
@@ -111,9 +111,9 @@ export async function initAppearanceSettings(): Promise<void> {
   ) as HTMLInputElement | null;
   if (inlineGifPlayback) {
     const saved = await idbGet<boolean>(INLINE_GIF_PLAYBACK);
-    inlineGifPlayback.checked = saved || false;
+    inlineGifPlayback.checked = saved === false;
     inlineGifPlayback.addEventListener("change", async () => {
-      await idbSet(INLINE_GIF_PLAYBACK, inlineGifPlayback.checked);
+      await idbSet(INLINE_GIF_PLAYBACK, !inlineGifPlayback.checked);
     });
   }
 

--- a/src/client/settings/general-tab.ts
+++ b/src/client/settings/general-tab.ts
@@ -2,6 +2,7 @@ import pkg from "../../../package.json";
 import {
   DISPLAY_ENGINE_PERFORMANCE,
   DISPLAY_SEARCH_SUGGESTIONS,
+  INLINE_GIF_PLAYBACK,
   OPEN_IN_NEW_TAB_KEY,
   POST_METHOD_ENABLED,
   THEME_KEY,
@@ -102,6 +103,17 @@ export async function initAppearanceSettings(): Promise<void> {
         DISPLAY_SEARCH_SUGGESTIONS,
         displaySearchSuggestions.checked,
       );
+    });
+  }
+
+  const inlineGifPlayback = document.getElementById(
+    "settings-inline-gif-playback",
+  ) as HTMLInputElement | null;
+  if (inlineGifPlayback) {
+    const saved = await idbGet<boolean>(INLINE_GIF_PLAYBACK);
+    inlineGifPlayback.checked = saved || false;
+    inlineGifPlayback.addEventListener("change", async () => {
+      await idbSet(INLINE_GIF_PLAYBACK, inlineGifPlayback.checked);
     });
   }
 

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -21,6 +21,7 @@ export const state: AppState = {
   displayEnginePerformance: true,
   displaySearchSuggestions: true,
   postMethodEnabled: false,
+  inlineGifPlayback: false,
   isInitialLoad: false,
   imageFilter: {},
 };

--- a/src/client/state.ts
+++ b/src/client/state.ts
@@ -21,7 +21,7 @@ export const state: AppState = {
   displayEnginePerformance: true,
   displaySearchSuggestions: true,
   postMethodEnabled: false,
-  inlineGifPlayback: false,
+  inlineGifPlayback: true,
   isInitialLoad: false,
   imageFilter: {},
 };

--- a/src/client/types/search.ts
+++ b/src/client/types/search.ts
@@ -13,6 +13,7 @@ export interface SearchResult {
   source: string;
   thumbnail?: string;
   imageUrl?: string;
+  isGif?: boolean;
   duration?: string;
 }
 

--- a/src/client/types/state.ts
+++ b/src/client/types/state.ts
@@ -23,6 +23,7 @@ export interface AppState {
   displayEnginePerformance: boolean;
   displaySearchSuggestions: boolean;
   postMethodEnabled: boolean;
+  inlineGifPlayback: boolean;
   isInitialLoad: boolean;
   imageFilter: ImageFilter;
 }

--- a/src/client/utils/streaming-search.ts
+++ b/src/client/utils/streaming-search.ts
@@ -16,7 +16,8 @@ import {
   renderResults,
   renderSidebar,
 } from "../modules/renderer/render";
-import { renderMediaEngineBar } from "../modules/renderer/render-media";
+import { appendMediaCards, renderMediaEngineBar } from "../modules/renderer/render-media";
+import { setupMediaObserver } from "../modules/media/media";
 import { state } from "../state";
 import {
   EngineTiming,
@@ -162,6 +163,7 @@ export async function performStreamingSearch(
   let firstResult = true;
   let currentResults: ScoredResult[] = [];
   const renderedUrls = new Set<string>();
+  const renderedImages: ScoredResult[] = [];
 
   const source = new EventSource(streamUrl);
   _activeSource = source;
@@ -184,17 +186,33 @@ export async function performStreamingSearch(
       engineTimings.push(data.timing);
     }
 
-    currentResults = data.results;
-    state.currentResults = currentResults;
-
-    if (firstResult) {
-      firstResult = false;
-      if (resultsList) resultsList.innerHTML = "";
-    }
-
     if (isImageType) {
-      renderResults(currentResults);
+      if (firstResult) {
+        firstResult = false;
+        if (resultsList) {
+          resultsList.innerHTML =
+            '<div class="image-grid"></div><div class="media-scroll-sentinel"></div>';
+        }
+      }
+      const grid = resultsList?.querySelector<HTMLElement>(".image-grid");
+      const fresh: ScoredResult[] = [];
+      for (const r of data.results) {
+        if (!renderedUrls.has(r.url)) {
+          renderedUrls.add(r.url);
+          fresh.push(r);
+          renderedImages.push(r);
+        }
+      }
+      currentResults = renderedImages;
+      state.currentResults = renderedImages;
+      if (grid && fresh.length) appendMediaCards(grid, fresh, "image");
     } else {
+      currentResults = data.results;
+      state.currentResults = currentResults;
+      if (firstResult) {
+        firstResult = false;
+        if (resultsList) resultsList.innerHTML = "";
+      }
       updateResults(resultsList, currentResults, renderedUrls);
       if (resultsList) attachVideoPlayers(resultsList);
     }
@@ -244,6 +262,7 @@ export async function performStreamingSearch(
     if (isImageType) {
       renderMediaEngineBar(data.engineTimings);
       if (sidebar) sidebar.innerHTML = "";
+      if (currentResults.length > 0) setupMediaObserver("images");
     } else if (type === "web") {
       void fetchGlancePanels(query, currentResults);
       void fetchSlotPanels(query, currentResults).then((panels) => {
@@ -266,7 +285,7 @@ export async function performStreamingSearch(
     }
 
     if (resultsList) attachVideoPlayers(resultsList);
-    renderPagination(MAX_PAGE, state.currentPage);
+    if (!isImageType) renderPagination(MAX_PAGE, state.currentPage);
   });
 
   source.addEventListener("error", (e) => {

--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -28,24 +28,6 @@ export const readImgFilter = (p: URLSearchParams): ImageFilter => {
   return f;
 };
 
-export const proxyImageUrl = (url: string): string => {
-  if (!url) return "";
-  if (url.includes("/api/proxy/")) return url;
-  return `${getBase()}/api/proxy/image?url=${encodeURIComponent(url)}`;
-};
-
-const _unwrapProxyImageUrl = (url: string): string => {
-  if (!url.includes("/api/proxy/image?")) return url;
-  const query = url.split("?", 2)[1]?.split("#", 1)[0];
-  return query ? new URLSearchParams(query).get("url") || url : url;
-};
-
-export const isGifImageUrl = (url: string): boolean => {
-  if (!url) return false;
-  const target = _unwrapProxyImageUrl(url);
-  return target.split(/[?#]/, 1)[0].toLowerCase().endsWith(".gif");
-};
-
 export const faviconHostname = (url: string): string => {
   try {
     return new URL(url).hostname;

--- a/src/client/utils/url.ts
+++ b/src/client/utils/url.ts
@@ -34,6 +34,18 @@ export const proxyImageUrl = (url: string): string => {
   return `${getBase()}/api/proxy/image?url=${encodeURIComponent(url)}`;
 };
 
+const _unwrapProxyImageUrl = (url: string): string => {
+  if (!url.includes("/api/proxy/image?")) return url;
+  const query = url.split("?", 2)[1]?.split("#", 1)[0];
+  return query ? new URLSearchParams(query).get("url") || url : url;
+};
+
+export const isGifImageUrl = (url: string): boolean => {
+  if (!url) return false;
+  const target = _unwrapProxyImageUrl(url);
+  return target.split(/[?#]/, 1)[0].toLowerCase().endsWith(".gif");
+};
+
 export const faviconHostname = (url: string): string => {
   try {
     return new URL(url).hostname;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -40,6 +40,8 @@
       "engine-performance-aria": "Display engine performance",
       "related-queries": "Display related search queries",
       "related-queries-aria": "Display related search queries",
+      "inline-gif-playback": "Play GIF image results inline",
+      "inline-gif-playback-aria": "Play GIF image results inline",
       "post-method": "Use POST method for search requests (Won't work with streaming results)",
       "post-method-aria": "Use POST method for search requests (Won't work with streaming results)",
       "post-method-tooltip": "POST method is not compatible with streaming results"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -40,8 +40,8 @@
       "engine-performance-aria": "Display engine performance",
       "related-queries": "Display related search queries",
       "related-queries-aria": "Display related search queries",
-      "inline-gif-playback": "Play GIF image results inline",
-      "inline-gif-playback-aria": "Play GIF image results inline",
+      "inline-gif-playback": "Disable GIF animation in image results",
+      "inline-gif-playback-aria": "Disable GIF animation in image results",
       "post-method": "Use POST method for search requests (Won't work with streaming results)",
       "post-method-aria": "Use POST method for search requests (Won't work with streaming results)",
       "post-method-tooltip": "POST method is not compatible with streaming results"

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -39,6 +39,8 @@
       "engine-performance-aria": "Afficher les performances des moteurs",
       "related-queries": "Afficher les requêtes de recherche connexes",
       "related-queries-aria": "Afficher les requêtes de recherche connexes",
+      "inline-gif-playback": "Lire les GIF dans les résultats d'images",
+      "inline-gif-playback-aria": "Lire les GIF dans les résultats d'images",
       "post-method": "Utiliser la méthode POST pour les requêtes de recherche (Ne fonctionne pas avec les résultats en flux)",
       "post-method-aria": "Utiliser la méthode POST pour les requêtes de recherche (Ne fonctionne pas avec les résultats en flux)",
       "post-method-tooltip": "La méthode POST n'est pas compatible avec les résultats en flux"

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -39,8 +39,8 @@
       "engine-performance-aria": "Afficher les performances des moteurs",
       "related-queries": "Afficher les requêtes de recherche connexes",
       "related-queries-aria": "Afficher les requêtes de recherche connexes",
-      "inline-gif-playback": "Lire les GIF dans les résultats d'images",
-      "inline-gif-playback-aria": "Lire les GIF dans les résultats d'images",
+      "inline-gif-playback": "Désactiver l'animation GIF dans les résultats d'images",
+      "inline-gif-playback-aria": "Désactiver l'animation GIF dans les résultats d'images",
       "post-method": "Utiliser la méthode POST pour les requêtes de recherche (Ne fonctionne pas avec les résultats en flux)",
       "post-method-aria": "Utiliser la méthode POST pour les requêtes de recherche (Ne fonctionne pas avec les résultats en flux)",
       "post-method-tooltip": "La méthode POST n'est pas compatible avec les résultats en flux"

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -39,6 +39,8 @@
       "engine-performance-aria": "הצג ביצועי מנוע",
       "related-queries": "הצג שאילתות חיפוש קשורות",
       "related-queries-aria": "הצג שאילתות חיפוש קשורות",
+      "inline-gif-playback": "הפעל GIF בתוצאות התמונות עצמן",
+      "inline-gif-playback-aria": "הפעל GIF בתוצאות התמונות עצמן",
       "post-method": "השתמש בשיטת POST לבקשות חיפוש (לא יעבוד עם תוצאות מוזרמות)",
       "post-method-aria": "השתמש בשיטת POST לבקשות חיפוש (לא יעבוד עם תוצאות מוזרמות)",
       "post-method-tooltip": "שיטת POST אינה תואמת לתוצאות מוזרמות"

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -39,8 +39,8 @@
       "engine-performance-aria": "הצג ביצועי מנוע",
       "related-queries": "הצג שאילתות חיפוש קשורות",
       "related-queries-aria": "הצג שאילתות חיפוש קשורות",
-      "inline-gif-playback": "הפעל GIF בתוצאות התמונות עצמן",
-      "inline-gif-playback-aria": "הפעל GIF בתוצאות התמונות עצמן",
+      "inline-gif-playback": "השבת אנימציית GIF בתוצאות התמונות",
+      "inline-gif-playback-aria": "השבת אנימציית GIF בתוצאות התמונות",
       "post-method": "השתמש בשיטת POST לבקשות חיפוש (לא יעבוד עם תוצאות מוזרמות)",
       "post-method-aria": "השתמש בשיטת POST לבקשות חיפוש (לא יעבוד עם תוצאות מוזרמות)",
       "post-method-tooltip": "שיטת POST אינה תואמת לתוצאות מוזרמות"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -39,6 +39,8 @@
       "engine-performance-aria": "Mostra le prestazioni dei motori",
       "related-queries": "Mostra query di ricerca correlate",
       "related-queries-aria": "Mostra query di ricerca correlate",
+      "inline-gif-playback": "Riproduci le GIF nei risultati immagini",
+      "inline-gif-playback-aria": "Riproduci le GIF nei risultati immagini",
       "post-method": "Usa il metodo POST per le richieste di ricerca (Non funziona con lo streaming dei risultati)",
       "post-method-aria": "Usa il metodo POST per le richieste di ricerca (Non funziona con lo streaming dei risultati)",
       "post-method-tooltip": "Il metodo POST non è compatibile con lo streaming dei risultati"

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -39,8 +39,8 @@
       "engine-performance-aria": "Mostra le prestazioni dei motori",
       "related-queries": "Mostra query di ricerca correlate",
       "related-queries-aria": "Mostra query di ricerca correlate",
-      "inline-gif-playback": "Riproduci le GIF nei risultati immagini",
-      "inline-gif-playback-aria": "Riproduci le GIF nei risultati immagini",
+      "inline-gif-playback": "Disabilita l'animazione GIF nei risultati immagini",
+      "inline-gif-playback-aria": "Disabilita l'animazione GIF nei risultati immagini",
       "post-method": "Usa il metodo POST per le richieste di ricerca (Non funziona con lo streaming dei risultati)",
       "post-method-aria": "Usa il metodo POST per le richieste di ricerca (Non funziona con lo streaming dei risultati)",
       "post-method-tooltip": "Il metodo POST non è compatibile con lo streaming dei risultati"

--- a/src/public/settings-public.html
+++ b/src/public/settings-public.html
@@ -114,6 +114,19 @@
               >
             </label>
 
+            <label class="settings-toggle-wrap degoog-toggle-wrap">
+              <input
+                type="checkbox"
+                id="settings-inline-gif-playback"
+                class="settings-toggle"
+                aria-label="{{t:settings-page.search-options.inline-gif-playback-aria}}"
+              />
+              <span class="toggle-slider degoog-toggle"></span>
+              <span class="settings-toggle-label"
+                >{{t:settings-page.search-options.inline-gif-playback}}</span
+              >
+            </label>
+
             <label
               class="settings-toggle-wrap degoog-toggle-wrap"
               title="{{t:settings-page.search-options.post-method-tooltip}}"

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -230,6 +230,19 @@
                   >
                 </label>
 
+                <label class="settings-toggle-wrap degoog-toggle-wrap">
+                  <input
+                    type="checkbox"
+                    id="settings-inline-gif-playback"
+                    class="settings-toggle"
+                    aria-label="{{t:settings-page.search-options.inline-gif-playback-aria}}"
+                  />
+                  <span class="toggle-slider degoog-toggle"></span>
+                  <span class="settings-toggle-label"
+                    >{{t:settings-page.search-options.inline-gif-playback}}</span
+                  >
+                </label>
+
                 <label
                   class="settings-toggle-wrap degoog-toggle-wrap"
                   title="{{t:settings-page.search-options.post-method-tooltip}}"

--- a/src/public/themes/degoog-theme/search-templates/image-card.html
+++ b/src/public/themes/degoog-theme/search-templates/image-card.html
@@ -2,9 +2,10 @@
   <img
     class="image-thumb"
     src="{{ thumbnail_url }}"
+    data-fallback="{{ fallback_url }}"
     alt="{{ title }}"
     loading="lazy"
-    onerror="this.parentElement.parentElement.style.display='none'"
+    onerror="this.src!==this.dataset.fallback?(this.src=this.dataset.fallback):this.closest('.image-card').style.display='none'"
   />
 </div>
 <div class="image-info">

--- a/src/public/themes/degoog-theme/search-templates/lightbox.html
+++ b/src/public/themes/degoog-theme/search-templates/lightbox.html
@@ -3,5 +3,5 @@
   &times;
 </button>
 <div class="img-lightbox-wrap" id="img-lightbox-wrap">
-  <img class="img-lightbox-img" id="img-lightbox-img" src="" alt="" />
+  <img class="img-lightbox-img" id="img-lightbox-img" src="" alt="" draggable="false" />
 </div>

--- a/src/server/extensions/commands/builtins/wikipedia/index.ts
+++ b/src/server/extensions/commands/builtins/wikipedia/index.ts
@@ -32,9 +32,8 @@ let _signProxyUrl: PluginContext["signProxyUrl"] | null = null;
 let _wikiCache!: TtlCache<WikiPage>;
 
 const _proxyImageUrl = (url: string): string => {
-  if (!url) return "";
-  if (_signProxyUrl) return _signProxyUrl(url);
-  return `/api/proxy/image?url=${encodeURIComponent(url)}`;
+  if (!url || !_signProxyUrl) return "";
+  return _signProxyUrl(url);
 };
 
 async function _fetchWikipedia(query: string): Promise<WikiPage | null> {

--- a/src/server/extensions/engines/registry.ts
+++ b/src/server/extensions/engines/registry.ts
@@ -48,6 +48,7 @@ export interface EngineDefinition {
   EngineClass: new () => SearchEngine;
   description?: string;
   disabledByDefault?: boolean;
+  /** @deprecated Legacy outgoing-fetch allowlist. Sign image URLs with ctx.signProxyUrl instead. */
   outgoingHosts?: string[];
   defaultTransport?: string;
 }
@@ -156,6 +157,7 @@ interface PluginEntry {
   description?: string;
   instance: SearchEngine;
   disabledByDefault?: boolean;
+  /** @deprecated Legacy outgoing-fetch allowlist. Sign image URLs with ctx.signProxyUrl instead. */
   outgoingHosts?: string[];
 }
 
@@ -244,6 +246,7 @@ export async function getEffectiveEngineRegistry(): Promise<{
   return [...builtinRegistry, ...plugins];
 }
 
+/** @deprecated Legacy outgoing-fetch allowlist. Sign image URLs with ctx.signProxyUrl instead. */
 export function getOutgoingAllowlist(): string[] {
   const fromBuiltins = BUILTIN_DEFINITIONS.flatMap(
     (d) => d.outgoingHosts ?? [],

--- a/src/server/routes/proxy.ts
+++ b/src/server/routes/proxy.ts
@@ -1,11 +1,9 @@
 import { Hono } from "hono";
-import { outgoingFetch, isUrlAllowedForOutgoing } from "../utils/outgoing";
+import { outgoingFetch } from "../utils/outgoing";
 import { verifyProxyUrl } from "../utils/proxy-sign";
 import { getRandomUserAgent } from "../utils/user-agents";
 
 const router = new Hono();
-
-const PROXY_FETCH_TIMEOUT_MS = 15_000;
 
 const CONTENT_TYPE_EXT: Record<string, string> = {
   "image/jpeg": ".jpg",
@@ -30,7 +28,8 @@ const getProxyFilename = (originalUrl: string, contentType: string): string => {
 };
 
 const PROXY_TIMEOUT_MS = 10_000;
-const MAX_CONTENT_LENGTH = 10 * 1024 * 1024;
+const MAX_CONTENT_LENGTH = 25 * 1024 * 1024;
+const MAX_REDIRECT_HOPS = 5;
 const ALLOWED_CONTENT_TYPES = [
   "image/jpeg",
   "image/png",
@@ -40,6 +39,35 @@ const ALLOWED_CONTENT_TYPES = [
   "image/avif",
   "image/x-icon",
 ];
+
+const followRedirects = async (
+  initial: string,
+  init: { headers: Record<string, string>; signal: AbortSignal },
+): Promise<Response | null> => {
+  let target = initial;
+  for (let hop = 0; hop <= MAX_REDIRECT_HOPS; hop++) {
+    try {
+      const parsed = new URL(target);
+      if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+    } catch {
+      return null;
+    }
+    const res = await outgoingFetch(target, {
+      signal: init.signal,
+      headers: init.headers,
+      redirect: "manual",
+    });
+    if (res.status < 300 || res.status >= 400) return res;
+    const loc = res.headers.get("location");
+    if (!loc) return res;
+    try {
+      target = new URL(loc, target).toString();
+    } catch {
+      return null;
+    }
+  }
+  return null;
+};
 
 router.get("/api/proxy/image", async (c) => {
   const url = c.req.query("url");
@@ -57,11 +85,9 @@ router.get("/api/proxy/image", async (c) => {
   }
 
   const sig = c.req.query("sig");
-  const allowed = (sig && verifyProxyUrl(url, sig)) || isUrlAllowedForOutgoing(url);
-  if (!allowed) {
-    return c.body("URL not allowed for outgoing fetch", 403);
+  if (!sig || !verifyProxyUrl(url, sig)) {
+    return c.body("Invalid or missing signature", 403);
   }
-
   const headers: Record<string, string> = {
     "User-Agent": getRandomUserAgent(),
     Accept: "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8",
@@ -76,14 +102,13 @@ router.get("/api/proxy/image", async (c) => {
   const timeout = setTimeout(() => controller.abort(), PROXY_TIMEOUT_MS);
 
   try {
-    const res = await outgoingFetch(url, {
+    const res = await followRedirects(url, {
       signal: controller.signal,
       headers,
-      redirect: "manual",
     });
     clearTimeout(timeout);
 
-    if (res.status >= 300 && res.status < 400) return c.body("Upstream error", 502);
+    if (!res) return c.body("Blocked redirect", 502);
     if (!res.ok) return c.body("Upstream error", 502);
 
     const contentType =
@@ -153,42 +178,6 @@ router.get("/api/proxy/favicon", async (c) => {
   }
 
   return c.body("Favicon not found", 404);
-});
-
-router.post("/api/proxy/fetch", async (c) => {
-  let body: { url?: string; headers?: Record<string, string> };
-  try {
-    body = await c.req.json<{
-      url?: string;
-      headers?: Record<string, string>;
-    }>();
-  } catch {
-    return c.json({ error: "Invalid JSON body" }, 400);
-  }
-  const url = body?.url?.trim();
-  if (!url) return c.json({ error: "Missing url" }, 400);
-  if (!isUrlAllowedForOutgoing(url)) {
-    return c.json({ error: "URL not allowed for outgoing fetch" }, 403);
-  }
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), PROXY_FETCH_TIMEOUT_MS);
-  try {
-    const res = await outgoingFetch(url, {
-      headers: body.headers ?? {},
-      signal: controller.signal,
-    });
-    clearTimeout(timeout);
-    const resBody = await res.arrayBuffer();
-    const contentType =
-      res.headers.get("content-type") ?? "application/octet-stream";
-    return new Response(resBody, {
-      status: res.status,
-      headers: { "Content-Type": contentType },
-    });
-  } catch {
-    clearTimeout(timeout);
-    return c.json({ error: "Proxy fetch failed" }, 502);
-  }
 });
 
 export default router;

--- a/src/server/routes/search/_tab-search-route.ts
+++ b/src/server/routes/search/_tab-search-route.ts
@@ -4,6 +4,7 @@ import { getSearchResultTabById } from "../../extensions/search-result-tabs/regi
 import { createSearchEngineContext } from "../../search";
 import type { EngineTiming, ScoredResult } from "../../types";
 import { applyDomainRules } from "./_domain-rules";
+import { signResultThumbnails } from "../../utils/proxy-sign";
 import { logger } from "../../utils/logger";
 import { isDisabled } from "../../utils/plugin-settings";
 import { getClientIp } from "../../utils/request";
@@ -119,7 +120,7 @@ export function registerTabSearchRoute(router: Hono): void {
       }
 
       const totalTime = Math.round(performance.now() - startTime);
-      const finalResults = await applyDomainRules(allResults);
+      const finalResults = signResultThumbnails(await applyDomainRules(allResults));
       return c.json({
         results: finalResults,
         totalPages,

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -96,6 +96,15 @@ const _normalizeUrl = (url: string): string => {
   }
 };
 
+const _isGifImageUrl = (url?: string): boolean => {
+  if (!url) return false;
+  try {
+    return new URL(url).pathname.toLowerCase().endsWith(".gif");
+  } catch {
+    return url.split(/[?#]/, 1)[0].toLowerCase().endsWith(".gif");
+  }
+};
+
 const _mergeIntoMap = (
   urlMap: Map<string, ScoredResult>,
   results: SearchResult[],
@@ -119,6 +128,13 @@ const _mergeIntoMap = (
       }
       if (r.thumbnail && !existing.thumbnail) {
         existing.thumbnail = r.thumbnail;
+      }
+      if (
+        r.imageUrl &&
+        (!existing.imageUrl ||
+          (!_isGifImageUrl(existing.imageUrl) && _isGifImageUrl(r.imageUrl)))
+      ) {
+        existing.imageUrl = r.imageUrl;
       }
       if (insecure) existing.insecure = true;
     } else {

--- a/src/server/search.ts
+++ b/src/server/search.ts
@@ -96,14 +96,8 @@ const _normalizeUrl = (url: string): string => {
   }
 };
 
-const _isGifImageUrl = (url?: string): boolean => {
-  if (!url) return false;
-  try {
-    return new URL(url).pathname.toLowerCase().endsWith(".gif");
-  } catch {
-    return url.split(/[?#]/, 1)[0].toLowerCase().endsWith(".gif");
-  }
-};
+const _urlIsGif = (url?: string): boolean =>
+  !!url && url.split(/[?#]/, 1)[0].toLowerCase().endsWith(".gif");
 
 const _mergeIntoMap = (
   urlMap: Map<string, ScoredResult>,
@@ -129,12 +123,9 @@ const _mergeIntoMap = (
       if (r.thumbnail && !existing.thumbnail) {
         existing.thumbnail = r.thumbnail;
       }
-      if (
-        r.imageUrl &&
-        (!existing.imageUrl ||
-          (!_isGifImageUrl(existing.imageUrl) && _isGifImageUrl(r.imageUrl)))
-      ) {
+      if (r.imageUrl && (!existing.imageUrl || (!existing.isGif && _urlIsGif(r.imageUrl)))) {
         existing.imageUrl = r.imageUrl;
+        existing.isGif = _urlIsGif(r.imageUrl);
       }
       if (insecure) existing.insecure = true;
     } else {
@@ -146,6 +137,7 @@ const _mergeIntoMap = (
         score: positionScore,
         sources: [r.source],
         insecure,
+        isGif: _urlIsGif(r.imageUrl),
       });
     }
   }

--- a/src/server/types/search.ts
+++ b/src/server/types/search.ts
@@ -62,6 +62,7 @@ export interface SearchResult {
   source: string;
   thumbnail?: string;
   imageUrl?: string;
+  isGif?: boolean;
   duration?: string;
 }
 

--- a/src/server/utils/outgoing.ts
+++ b/src/server/utils/outgoing.ts
@@ -36,6 +36,7 @@ export function parseOutgoingTransport(raw: string | undefined): string {
 
 let allowedHosts: Set<string> | null = null;
 
+/** @deprecated Legacy outgoing-fetch allowlist. Sign image URLs with ctx.signProxyUrl instead. */
 export function setOutgoingAllowlist(hosts: string[]): void {
   if (!hosts || hosts.length === 0) {
     allowedHosts = new Set();
@@ -72,6 +73,7 @@ function parseProxyUrlsList(rawList: string[]): string[] {
   return out;
 }
 
+/** @deprecated Legacy outgoing-fetch allowlist. Sign image URLs with ctx.signProxyUrl instead. */
 export function isUrlAllowedForOutgoing(url: string): boolean {
   try {
     const parsed = new URL(url);

--- a/src/styles/components/overrides/_media.scss
+++ b/src/styles/components/overrides/_media.scss
@@ -33,7 +33,6 @@
   transform-origin: center center;
   user-select: none;
   -webkit-user-drag: none;
-  pointer-events: none;
 }
 
 .media-engine-bar {

--- a/tests/public/constants-state-timeFilter.test.ts
+++ b/tests/public/constants-state-timeFilter.test.ts
@@ -35,6 +35,6 @@ describe("public/state", () => {
     expect(state).toHaveProperty("currentType", "web");
     expect(state).toHaveProperty("currentPage", 1);
     expect(state).toHaveProperty("currentTimeFilter", "any");
-    expect(state).toHaveProperty("inlineGifPlayback", false);
+    expect(state).toHaveProperty("inlineGifPlayback", true);
   });
 });

--- a/tests/public/constants-state-timeFilter.test.ts
+++ b/tests/public/constants-state-timeFilter.test.ts
@@ -35,5 +35,6 @@ describe("public/state", () => {
     expect(state).toHaveProperty("currentType", "web");
     expect(state).toHaveProperty("currentPage", 1);
     expect(state).toHaveProperty("currentTimeFilter", "any");
+    expect(state).toHaveProperty("inlineGifPlayback", false);
   });
 });

--- a/tests/public/url.test.ts
+++ b/tests/public/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from "bun:test";
-import { buildSearchUrl, faviconUrl, isGifImageUrl, proxyImageUrl } from "../../src/client/utils/url";
+import { buildSearchUrl, faviconUrl } from "../../src/client/utils/url";
 import { state } from "../../src/client/state";
 
 describe("public/url", () => {
@@ -7,16 +7,6 @@ describe("public/url", () => {
     const g = globalThis as unknown as { window?: { __DEGOOG_BASE_URL__?: string } };
     if (!g.window) g.window = {};
     g.window.__DEGOOG_BASE_URL__ = "";
-  });
-
-  test("proxyImageUrl returns empty for empty url", () => {
-    expect(proxyImageUrl("")).toBe("");
-  });
-
-  test("proxyImageUrl returns path with encoded url", () => {
-    const out = proxyImageUrl("https://example.com/img.png");
-    expect(out).toContain("/api/proxy/image");
-    expect(out).toContain("url=");
   });
 
   test("faviconUrl returns empty for invalid url", () => {
@@ -28,12 +18,6 @@ describe("public/url", () => {
     expect(out).toContain("/api/proxy/favicon");
     expect(out).toContain("domain=");
     expect(out).toContain("example.com");
-  });
-
-  test("isGifImageUrl detects gif URLs", () => {
-    expect(isGifImageUrl("https://example.com/image.gif?size=large")).toBe(true);
-    expect(isGifImageUrl("https://example.com/image.webp")).toBe(false);
-    expect(isGifImageUrl("https://example.gif/gif.webp")).toBe(false);
   });
 
   test("buildSearchUrl includes query and engine params", () => {

--- a/tests/public/url.test.ts
+++ b/tests/public/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll } from "bun:test";
-import { buildSearchUrl, proxyImageUrl, faviconUrl } from "../../src/client/utils/url";
+import { buildSearchUrl, faviconUrl, isGifImageUrl, proxyImageUrl } from "../../src/client/utils/url";
 import { state } from "../../src/client/state";
 
 describe("public/url", () => {
@@ -28,6 +28,12 @@ describe("public/url", () => {
     expect(out).toContain("/api/proxy/favicon");
     expect(out).toContain("domain=");
     expect(out).toContain("example.com");
+  });
+
+  test("isGifImageUrl detects gif URLs", () => {
+    expect(isGifImageUrl("https://example.com/image.gif?size=large")).toBe(true);
+    expect(isGifImageUrl("https://example.com/image.webp")).toBe(false);
+    expect(isGifImageUrl("https://example.gif/gif.webp")).toBe(false);
   });
 
   test("buildSearchUrl includes query and engine params", () => {

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -44,13 +44,13 @@ describe("search", () => {
       expect(out[0].url).toBe("https://a.com");
     });
 
-    test("prefers gif image urls when merging duplicates", () => {
-      const cases = [
-        ["https://cdn.example.com/a.gif", "https://cdn.example.com/a.gif"],
-        ["https://cdn.example.com/a.jpg", "https://cdn.example.com/a.webp"],
+    test("prefers gif imageUrl when merging duplicates and sets isGif", () => {
+      const cases: [string, string, boolean][] = [
+        ["https://cdn.example.com/a.gif", "https://cdn.example.com/a.gif", true],
+        ["https://cdn.example.com/a.jpg", "https://cdn.example.com/a.webp", false],
       ];
 
-      for (const [newImageUrl, expected] of cases) {
+      for (const [newImageUrl, expectedUrl, expectedIsGif] of cases) {
         const existing = [
           scored(
             {
@@ -69,7 +69,8 @@ describe("search", () => {
         ];
 
         const out = mergeNewResults(existing, newResults);
-        expect(out[0].imageUrl).toBe(expected);
+        expect(out[0].imageUrl).toBe(expectedUrl);
+        expect(!!out[0].isGif).toBe(expectedIsGif);
       }
     });
   });

--- a/tests/unit/search.test.ts
+++ b/tests/unit/search.test.ts
@@ -43,6 +43,35 @@ describe("search", () => {
       const out = mergeNewResults(existing, newResults);
       expect(out[0].url).toBe("https://a.com");
     });
+
+    test("prefers gif image urls when merging duplicates", () => {
+      const cases = [
+        ["https://cdn.example.com/a.gif", "https://cdn.example.com/a.gif"],
+        ["https://cdn.example.com/a.jpg", "https://cdn.example.com/a.webp"],
+      ];
+
+      for (const [newImageUrl, expected] of cases) {
+        const existing = [
+          scored(
+            {
+              ...result("https://a.com", "E1"),
+              imageUrl: "https://cdn.example.com/a.webp",
+            },
+            5,
+            ["E1"],
+          ),
+        ];
+        const newResults = [
+          {
+            ...result("https://a.com", "E2"),
+            imageUrl: newImageUrl,
+          },
+        ];
+
+        const out = mergeNewResults(existing, newResults);
+        expect(out[0].imageUrl).toBe(expected);
+      }
+    });
   });
 
   describe("scoreResults", () => {


### PR DESCRIPTION
## This PR adds a toggle that enables inline GIF playback in the images tab.

The change only targets URLs that end with `.gif`, other formats like `.webp` are not always animated.

Open to suggestions on better detection for animated content.

<img width="1200" height="517" alt="image" src="https://github.com/user-attachments/assets/cb84d4c4-cae9-442c-8c28-60385ae5b417" />
<img width="1309" height="1869" alt="Recording2026-05-18at22 29 08-ezgif com-gif-to-webp-converter" src="https://github.com/user-attachments/assets/beee534a-2de4-429b-bfab-426c3a9099c2" />

(sorry for the weird purple tint, just Wayland things)

