### PR TITLE
Feat/trailing bang support

### DIFF
--- a/docs/engines.html
+++ b/docs/engines.html
@@ -183,7 +183,7 @@
           <ul>
             <li>
               <strong>bangShortcut</strong>: Lets users type a shortcut like
-              <code>!shortcut query</code> to search only this engine (like
+              <code>!shortcut query</code> or <code>query !shortcut</code> to search only this engine (like
               setting <code>bangShortcut: "ecosia"</code> so users can type
               <code>!ecosia linux</code>).
             </li>

--- a/docs/plugins.html
+++ b/docs/plugins.html
@@ -164,11 +164,11 @@
           <h2>Folder structure</h2>
           <pre><code>data/plugins/
   my-plugin/
-    index.js        
-    template.html   
-    style.css       
-    script.js       
-    card.html       
+    index.js
+    template.html
+    style.css
+    script.js
+    card.html
     author.json     </code></pre>
           <p>
             Your entry file needs to be <code>index.js</code>,
@@ -261,7 +261,7 @@
           <h2 id="bang-commands">Bang commands</h2>
           <p>
             Bang commands run whenever you type
-            <code>!trigger something</code> into the search bar. You need to
+            <code>!trigger something</code> or <code>something !trigger</code> into the search bar. You need to
             export a single object using <code>export default</code> or
             <code>export const command</code> containing these properties:
           </p>
@@ -277,8 +277,8 @@
             </li>
             <li>
               <strong>execute(args, context)</strong> (async): The
-              <code>args</code> parameter contains whatever text follows your
-              trigger. You must return an object containing a
+              <code>args</code> parameter contains whatever text follows or precedes
+              your trigger. You must return an object containing a
               <code>title</code> string and an <code>html</code> string. You can
               also include an optional <code>totalPages</code> number.
             </li>

--- a/docs/repo/PUBLIC_INSTANCES.md
+++ b/docs/repo/PUBLIC_INSTANCES.md
@@ -1,6 +1,7 @@
 # degoog public instances
 
 Some amazing people around the web decided to make their degoog instances available for everyone to use, and they 100% deserve a shout-out!
+P.s. I do not have any control over these nor I assume any responsibility on what people choose to do with them.
 
 ## First ever public instance
 
@@ -15,3 +16,5 @@ Some amazing people around the web decided to make their degoog instances availa
 [https://degoog.org/](https://degoog.org/)
 
 [https://search.gglvxd.net/](https://search.gglvxd.net/)
+
+[https://degoog.ogservers.org/](https://degoog.ogservers.org/)

--- a/src/client/utils/search/search-actions-perform.ts
+++ b/src/client/utils/search/search-actions-perform.ts
@@ -108,7 +108,7 @@ export async function performSearch(
     }
   }
 
-  if (query.trim().startsWith("!")) {
+  if (query.trim().startsWith("!") || /\s!\S+$/.test(query.trim())) {
     state.currentQuery = query;
     return _performBangCommand(query, resolvedType, page || 1, isInit);
   }

--- a/src/server/extensions/commands/registry.ts
+++ b/src/server/extensions/commands/registry.ts
@@ -392,12 +392,22 @@ export type BangMatch =
 
 export function matchBangCommand(query: string): BangMatch | null {
   const trimmed = query.trim();
-  if (!trimmed.startsWith("!")) return null;
-  const withoutBang = trimmed.slice(1);
-  const spaceIdx = withoutBang.indexOf(" ");
-  const trigger =
-    spaceIdx === -1 ? withoutBang : withoutBang.slice(0, spaceIdx);
-  const args = spaceIdx === -1 ? "" : withoutBang.slice(spaceIdx + 1);
+
+  let trigger: string;
+  let args: string;
+
+  if (trimmed.startsWith("!")) {
+    const withoutBang = trimmed.slice(1);
+    const spaceIdx = withoutBang.indexOf(" ");
+    trigger = spaceIdx === -1 ? withoutBang : withoutBang.slice(0, spaceIdx);
+    args = spaceIdx === -1 ? "" : withoutBang.slice(spaceIdx + 1);
+  } else {
+    const trailingMatch = trimmed.match(/\s!(\S+)$/);
+    if (!trailingMatch) return null;
+    trigger = trailingMatch[1];
+    args = trimmed.slice(0, trailingMatch.index!).trim();
+  }
+
   const lowerTrigger = trigger.toLowerCase();
 
   const map = getCommandMap();

--- a/tests/commands/registry.test.ts
+++ b/tests/commands/registry.test.ts
@@ -48,4 +48,26 @@ describe("commands registry", () => {
     expect(matchBangCommand("help")).toBeNull();
     expect(matchBangCommand("foo")).toBeNull();
   });
+
+  test("matchBangCommand parses trailing bang: 'some query !help'", () => {
+    const match = matchBangCommand("some query !help");
+    expect(match).not.toBeNull();
+    if (!match) return;
+    expect(match.type).toBe("command");
+    if (match.type === "command") {
+      expect(match.command.trigger).toBe("help");
+      expect(match.args).toBe("some query");
+    }
+  });
+
+  test("matchBangCommand trailing bang returns null without space before !", () => {
+    expect(matchBangCommand("foo!help")).toBeNull();
+  });
+
+  test("matchBangCommand leading bang still takes priority", () => {
+    const match = matchBangCommand("!help trailing text");
+    expect(match).not.toBeNull();
+    if (!match || match.type !== "command") return;
+    expect(match.args).toBe("trailing text");
+  });
 });


### PR DESCRIPTION
# Description
This pr makes a slight modification to the way bangs work. Currently, bangs only work when placed at the _beginning_ of a query, e.g. `!w pizza`. 
This pr changes the parsing slightly so that bangs are also matched at the _end_ of a query, e.g. `pizza !w`. 

The exact behavior: 
- `pizza !w` now searches wikipedia for pizza
- `pizza !w restaurants` doesn't trigger the wikipedia bang
- `!r pizza !w` still searches **reddit** for pizza, as leading bangs take precedence over trailing bangs. 

# Context
I'm testing `degoog` as an alternative to Kagi, which copies its bang behavior from DuckDuckGo. Both these search engines allow bangs at both the beginning and end of a query. I find myself including them at the end 90% of the time, as I usually realize halfway through the query that a more focused search might be better. 

# Changes
- Minor update to the parsing logic in `src/client/utils/search/search-actions-perform.ts` that adds an OR (`||`) statement with an additional regex `/\s!\S+$/` (i.e. 'a space + an exclamation mark + a series of non-space chars + line termination)
- an additional `else` statement in `src/server/extensions/commands/registry.ts` for end-of-query bang/arg parsing
- tests (see below)
- documentation updates

# testing
- tests in `tests/commands/registry.test.ts`, namely:
  - `"matchBangCommand parses trailing bang: 'some query !help'"`
  - `"matchBangCommand trailing bang returns null without space before !"`
  - `"matchBangCommand leading bang still takes priority"`
- built + deployed a docker container to my personal instance and manually verified it works (which it does, but only after a hard refresh) 