### PR TITLE
Add list setting field type to extension settings

### DIFF
--- a/src/client/modules/modals/settings-modal/list-field-data.ts
+++ b/src/client/modules/modals/settings-modal/list-field-data.ts
@@ -9,7 +9,7 @@ export const isListDisplay = (sub: SettingField): boolean =>
   sub.type === "info";
 
 const _isFillable = (sub: SettingField): boolean =>
-  !isListToggle(sub) && !isListDisplay(sub) && sub.type !== "select";
+  !isListToggle(sub) && !isListDisplay(sub);
 
 export const defaultListRow = (itemSchema: SettingField[]): ListRow => {
   const row: ListRow = {};

--- a/src/client/modules/modals/settings-modal/list-field-data.ts
+++ b/src/client/modules/modals/settings-modal/list-field-data.ts
@@ -1,0 +1,75 @@
+import type { SettingField } from "../../../types";
+
+export type ListRow = Record<string, string>;
+
+export const isListToggle = (sub: SettingField): boolean =>
+  sub.type === "toggle";
+
+export const isListDisplay = (sub: SettingField): boolean =>
+  sub.type === "info";
+
+const _isFillable = (sub: SettingField): boolean =>
+  !isListToggle(sub) && !isListDisplay(sub) && sub.type !== "select";
+
+export const defaultListRow = (itemSchema: SettingField[]): ListRow => {
+  const row: ListRow = {};
+  for (const sub of itemSchema) {
+    row[sub.key] = sub.default != null ? String(sub.default) : "";
+  }
+  return row;
+};
+
+export const parseListValue = (
+  raw: string | string[] | undefined,
+  itemSchema: SettingField[],
+): ListRow[] => {
+  let parsed: unknown = raw;
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (trimmed === "") return [];
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return [];
+    }
+  }
+  if (!Array.isArray(parsed)) return [];
+  const rows: ListRow[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== "object" || Array.isArray(item)) continue;
+    const source = item as Record<string, unknown>;
+    const row: ListRow = {};
+    for (const sub of itemSchema) {
+      const v = source[sub.key];
+      if (isListToggle(sub)) {
+        row[sub.key] = v === true || v === "true" ? "true" : "false";
+      } else {
+        row[sub.key] = v == null ? "" : String(v);
+      }
+    }
+    rows.push(row);
+  }
+  return rows;
+};
+
+const _rowHasContent = (row: ListRow, itemSchema: SettingField[]): boolean => {
+  const fillable = itemSchema.filter(_isFillable);
+  if (fillable.length === 0) return true;
+  return fillable.some((sub) => (row[sub.key] ?? "").trim() !== "");
+};
+
+export const serializeRows = (
+  rows: ListRow[],
+  itemSchema: SettingField[],
+): string => {
+  return JSON.stringify(rows.filter((row) => _rowHasContent(row, itemSchema)));
+};
+
+export const rowSummary = (row: ListRow, itemSchema: SettingField[]): string => {
+  const parts = itemSchema
+    .filter((sub) => !isListToggle(sub) && !isListDisplay(sub))
+    .map((sub) => (row[sub.key] ?? "").trim())
+    .filter(Boolean)
+    .slice(0, 2);
+  return parts.length ? parts.join(" · ") : "…";
+};

--- a/src/client/modules/modals/settings-modal/list-field.ts
+++ b/src/client/modules/modals/settings-modal/list-field.ts
@@ -17,10 +17,10 @@ const _renderToggle = (sub: SettingField, value: string): string => {
   const checked = value === "true" ? " checked" : "";
   return `<label class="ext-list-sub ext-list-sub--toggle">
       <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
-      <label class="engine-toggle degoog-toggle-wrap degoog-toggle-wrap--transparent">
+      <div class="engine-toggle degoog-toggle-wrap degoog-toggle-wrap--transparent">
         <input type="checkbox" class="ext-list-subfield" data-subkey="${escapeHtml(sub.key)}" data-subtype="toggle"${checked}>
         <span class="toggle-slider degoog-toggle"></span>
-      </label>
+      </div>
     </label>`;
 };
 

--- a/src/client/modules/modals/settings-modal/list-field.ts
+++ b/src/client/modules/modals/settings-modal/list-field.ts
@@ -1,0 +1,229 @@
+import { escapeHtml } from "../../../utils/dom";
+import { renderMdInline } from "../../../utils/md";
+import {
+  isListToggle,
+  isListDisplay,
+  defaultListRow,
+  parseListValue,
+  serializeRows,
+  rowSummary,
+  type ListRow,
+} from "./list-field-data";
+import type { SettingField, ExtensionMeta } from "../../../types";
+
+const t = window.scopedT("core");
+
+const _renderToggle = (sub: SettingField, value: string): string => {
+  const checked = value === "true" ? " checked" : "";
+  return `<label class="ext-list-sub ext-list-sub--toggle">
+      <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
+      <label class="engine-toggle degoog-toggle-wrap degoog-toggle-wrap--transparent">
+        <input type="checkbox" class="ext-list-subfield" data-subkey="${escapeHtml(sub.key)}" data-subtype="toggle"${checked}>
+        <span class="toggle-slider degoog-toggle"></span>
+      </label>
+    </label>`;
+};
+
+const _renderInfo = (sub: SettingField): string => {
+  const desc = sub.description
+    ? `<span class="ext-field-desc">${renderMdInline(sub.description)}</span>`
+    : "";
+  const hasValue = sub.default != null && sub.default !== "";
+  const valueHtml = hasValue
+    ? `<input class="ext-field-input degoog-input" type="text" value="${escapeHtml(sub.default ?? "")}" disabled>`
+    : "";
+  return `<label class="ext-list-sub">
+      <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
+      ${valueHtml}
+      ${desc}
+    </label>`;
+};
+
+const _renderTextarea = (sub: SettingField, value: string): string => {
+  return `<label class="ext-list-sub">
+      <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
+      <textarea class="ext-field-input ext-list-subfield degoog-input" data-subkey="${escapeHtml(sub.key)}" data-subtype="text" rows="2" placeholder="${escapeHtml(sub.placeholder || "")}" autocomplete="off">${escapeHtml(value)}</textarea>
+    </label>`;
+};
+
+const _renderSelect = (sub: SettingField, value: string): string => {
+  const options = sub.options ?? [];
+  const selected = options.includes(value) ? value : (options[0] ?? "");
+  const opts = options
+    .map((opt, i) => {
+      const optLabel = sub.optionLabels?.[i] ?? opt;
+      return `<option value="${escapeHtml(opt)}"${opt === selected ? " selected" : ""}>${escapeHtml(optLabel)}</option>`;
+    })
+    .join("");
+  return `<label class="ext-list-sub">
+      <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
+      <div class="ext-field-select-wrap degoog-select-wrap">
+        <select class="ext-field-input ext-list-subfield ext-field-select degoog-input" data-subkey="${escapeHtml(sub.key)}" data-subtype="text">${opts}</select>
+      </div>
+    </label>`;
+};
+
+const _inputTypeFor = (type: SettingField["type"]): string => {
+  if (type === "url") return "url";
+  if (type === "number") return "number";
+  if (type === "password") return "password";
+  return "text";
+};
+
+const _renderInput = (sub: SettingField, value: string): string => {
+  const inputType = _inputTypeFor(sub.type);
+  return `<label class="ext-list-sub">
+      <span class="ext-list-sub-label">${escapeHtml(sub.label)}</span>
+      <input class="ext-field-input ext-list-subfield degoog-input" type="${inputType}" data-subkey="${escapeHtml(sub.key)}" data-subtype="text" value="${escapeHtml(value)}" placeholder="${escapeHtml(sub.placeholder || "")}" autocomplete="off">
+    </label>`;
+};
+
+const _renderSubField = (sub: SettingField, row: ListRow): string => {
+  const value = row[sub.key] ?? "";
+  if (isListToggle(sub)) return _renderToggle(sub, value);
+  if (isListDisplay(sub)) return _renderInfo(sub);
+  if (sub.type === "textarea") return _renderTextarea(sub, value);
+  if (sub.type === "select") return _renderSelect(sub, value);
+  return _renderInput(sub, value);
+};
+
+const _renderRow = (row: ListRow, itemSchema: SettingField[]): string => {
+  const editor = itemSchema
+    .map((sub) => _renderSubField(sub, row))
+    .join("");
+  return `<div class="ext-list-row">
+      <div class="ext-list-row-head">
+        <span class="ext-list-row-summary">${escapeHtml(rowSummary(row, itemSchema))}</span>
+        <button type="button" class="ext-list-row-edit" aria-label="${escapeHtml(t("settings-page.modal.field-edit-aria"))}">✎</button>
+        <button type="button" class="ext-list-row-remove" aria-label="${escapeHtml(t("settings-page.modal.field-remove-aria"))}">×</button>
+      </div>
+      <div class="ext-list-row-editor" hidden>${editor}</div>
+    </div>`;
+};
+
+export const renderListField = (
+  field: SettingField,
+  ext: ExtensionMeta,
+): string => {
+  const itemSchema = field.itemSchema ?? [];
+  const rows = parseListValue(ext.settings[field.key], itemSchema);
+  const descHtml = field.description
+    ? `<p class="ext-field-desc">${renderMdInline(field.description)}</p>`
+    : "";
+  const addLabel = escapeHtml(field.addLabel || t("settings-page.modal.field-add"));
+  const schemaAttr = encodeURIComponent(JSON.stringify(itemSchema));
+  const rowsHtml = rows.map((row) => _renderRow(row, itemSchema)).join("");
+  return `<div class="ext-field" data-key="${escapeHtml(field.key)}" data-type="list" data-item-schema="${schemaAttr}">
+      <label class="ext-field-label">${escapeHtml(field.label)}</label>
+      <div class="ext-list">
+        <div class="ext-list-rows">${rowsHtml}</div>
+        <button type="button" class="ext-list-add btn btn--secondary degoog-btn degoog-btn--secondary">${addLabel}</button>
+      </div>
+      <input type="hidden" id="field-${escapeHtml(field.key)}" class="ext-field-list-value">
+      ${descHtml}
+    </div>`;
+};
+
+const _readSchema = (fieldEl: HTMLElement): SettingField[] => {
+  try {
+    const raw = fieldEl.dataset.itemSchema || "";
+    const parsed = JSON.parse(raw ? decodeURIComponent(raw) : "[]") as unknown;
+    return Array.isArray(parsed) ? (parsed as SettingField[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const _collectRow = (
+  rowEl: HTMLElement,
+  itemSchema: SettingField[],
+): ListRow => {
+  const row: ListRow = {};
+  rowEl
+    .querySelectorAll<HTMLElement>(".ext-list-subfield")
+    .forEach((input) => {
+      const key = input.dataset.subkey;
+      if (!key) return;
+      if (input.dataset.subtype === "toggle") {
+        row[key] = (input as HTMLInputElement).checked ? "true" : "false";
+      } else {
+        row[key] = (input as HTMLInputElement | HTMLTextAreaElement).value.trim();
+      }
+    });
+  for (const sub of itemSchema) {
+    if (!(sub.key in row)) row[sub.key] = "";
+  }
+  return row;
+};
+
+export const initListFields = (container: HTMLElement): void => {
+  container
+    .querySelectorAll<HTMLElement>(".ext-field[data-type='list']")
+    .forEach((fieldEl) => _initOne(fieldEl));
+};
+
+const _initOne = (fieldEl: HTMLElement): void => {
+  const itemSchema = _readSchema(fieldEl);
+  const rowsEl = fieldEl.querySelector<HTMLElement>(".ext-list-rows");
+  const addBtn = fieldEl.querySelector<HTMLElement>(".ext-list-add");
+  const hidden = fieldEl.querySelector<HTMLInputElement>(
+    ".ext-field-list-value",
+  );
+  if (!rowsEl || !addBtn || !hidden) return;
+
+  const sync = (): void => {
+    const rows = [
+      ...rowsEl.querySelectorAll<HTMLElement>(".ext-list-row"),
+    ].map((rowEl) => _collectRow(rowEl, itemSchema));
+    hidden.value = serializeRows(rows, itemSchema);
+  };
+
+  const updateSummary = (rowEl: HTMLElement): void => {
+    const summary = rowEl.querySelector<HTMLElement>(".ext-list-row-summary");
+    if (summary) {
+      summary.textContent = rowSummary(_collectRow(rowEl, itemSchema), itemSchema) || "…";
+    }
+  };
+
+  const bindRow = (rowEl: HTMLElement): void => {
+    const editor = rowEl.querySelector<HTMLElement>(".ext-list-row-editor");
+    rowEl
+      .querySelector(".ext-list-row-edit")
+      ?.addEventListener("click", () => {
+        if (editor) editor.hidden = !editor.hidden;
+      });
+    rowEl
+      .querySelector(".ext-list-row-remove")
+      ?.addEventListener("click", () => {
+        rowEl.remove();
+        sync();
+      });
+    rowEl.querySelectorAll<HTMLElement>(".ext-list-subfield").forEach((input) => {
+      const handler = (): void => {
+        updateSummary(rowEl);
+        sync();
+      };
+      input.addEventListener("input", handler);
+      input.addEventListener("change", handler);
+    });
+  };
+
+  rowsEl
+    .querySelectorAll<HTMLElement>(".ext-list-row")
+    .forEach((rowEl) => bindRow(rowEl));
+
+  addBtn.addEventListener("click", () => {
+    const wrap = document.createElement("div");
+    wrap.innerHTML = _renderRow(defaultListRow(itemSchema), itemSchema);
+    const rowEl = wrap.firstElementChild as HTMLElement | null;
+    if (!rowEl) return;
+    const editor = rowEl.querySelector<HTMLElement>(".ext-list-row-editor");
+    if (editor) editor.hidden = false;
+    rowsEl.appendChild(rowEl);
+    bindRow(rowEl);
+    sync();
+    rowEl.querySelector<HTMLElement>(".ext-list-subfield")?.focus();
+  });
+
+  sync();
+};

--- a/src/client/modules/modals/settings-modal/modal-fields.ts
+++ b/src/client/modules/modals/settings-modal/modal-fields.ts
@@ -1,5 +1,6 @@
 import { escapeHtml } from "../../../utils/dom";
 import { renderMdInline } from "../../../utils/md";
+import { renderListField } from "./list-field";
 import type { SettingField, ExtensionMeta } from "../../../types";
 
 const t = window.scopedT("core");
@@ -62,6 +63,12 @@ export function readLiveSettingFieldValue(
   if (type === "urllist") {
     const hidden = fieldEl.querySelector<HTMLInputElement>(
       ".ext-field-urllist-value",
+    );
+    return hidden?.value?.trim() ?? "";
+  }
+  if (type === "list") {
+    const hidden = fieldEl.querySelector<HTMLInputElement>(
+      ".ext-field-list-value",
     );
     return hidden?.value?.trim() ?? "";
   }
@@ -249,15 +256,23 @@ export const renderField = (
     const descriptionHtml = field.description
       ? `<p class="ext-field-desc">${renderMdInline(field.description)}</p>`
       : "";
+    const hasValue = field.default != null && field.default !== "";
+    const valueHtml = hasValue
+      ? `<input class="ext-field-input degoog-input" type="text" value="${escapeHtml(field.default ?? "")}" disabled>`
+      : "";
     return `<div class="ext-field" data-key="${escapeHtml(field.key)}" data-type="info">
       <label class="ext-field-label">${escapeHtml(field.label)}</label>
-      <input class="ext-field-input degoog-input" type="text" value="${escapeHtml(field.default ?? "")}" disabled>
+      ${valueHtml}
       ${descriptionHtml}
     </div>`;
   }
 
   if (field.type === "urllist") {
     return _wrapVisibleWhen(field, _renderUrlListField(field, ext), ext);
+  }
+
+  if (field.type === "list") {
+    return _wrapVisibleWhen(field, renderListField(field, ext), ext);
   }
 
   if (field.type === "toggle") {

--- a/src/client/modules/modals/settings-modal/modal.ts
+++ b/src/client/modules/modals/settings-modal/modal.ts
@@ -154,7 +154,9 @@ const _advancedFieldDiffersFromDefault = (
 
   if (field.type === "list") {
     const val = typeof raw === "string" ? raw.trim() : "";
-    return val !== "" && val !== "[]";
+    const normalized = val === "[]" ? "" : val;
+    const def = defaultStr === "[]" ? "" : defaultStr;
+    return normalized !== def;
   }
 
   if (raw === undefined) {

--- a/src/client/modules/modals/settings-modal/modal.ts
+++ b/src/client/modules/modals/settings-modal/modal.ts
@@ -1,4 +1,5 @@
 import { renderField, initUrlList, syncConditionalFields } from "./modal-fields";
+import { initListFields } from "./list-field";
 import { getBase } from "../../../utils/base-url";
 import { getStoredToken } from "../../settings/settings";
 import { jsonHeaders } from "../../../utils/request";
@@ -114,6 +115,13 @@ const _collectValues = (): Record<string, string | string[]> => {
       }
       return;
     }
+    if (type === "list") {
+      const hidden = fieldEl.querySelector<HTMLInputElement>(
+        ".ext-field-list-value",
+      );
+      values[key] = hidden?.value?.trim() || "[]";
+      return;
+    }
 
     const input =
       fieldEl.querySelector<HTMLTextAreaElement>("textarea") ||
@@ -142,6 +150,11 @@ const _advancedFieldDiffersFromDefault = (
 
   if (field.type === "urllist") {
     return Array.isArray(raw) && raw.length > 0;
+  }
+
+  if (field.type === "list") {
+    const val = typeof raw === "string" ? raw.trim() : "";
+    return val !== "" && val !== "[]";
   }
 
   if (raw === undefined) {
@@ -231,6 +244,7 @@ export function openModal(ext: ExtensionMeta): void {
       });
     _initTestButton(bodyEl);
     initUrlList(bodyEl);
+    initListFields(bodyEl);
     syncConditionalFields(bodyEl);
     bodyEl
       .querySelectorAll<HTMLElement>(".ext-field-input--configured")

--- a/src/client/types/extension.ts
+++ b/src/client/types/extension.ts
@@ -7,6 +7,7 @@ export type SettingFieldType =
   | "textarea"
   | "select"
   | "urllist"
+  | "list"
   | "info";
 
 export interface SettingField {
@@ -22,6 +23,8 @@ export interface SettingField {
   default?: string;
   advanced?: boolean;
   visibleWhen?: { key: string; equals: string };
+  itemSchema?: SettingField[];
+  addLabel?: string;
 }
 
 export interface ExtensionMeta {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -83,8 +83,8 @@
           "desc": "For single-user LAN or homelab deployments where convenience matters and the network is trusted."
         },
         "private-team": {
-          "label": "Private Team / Semi-Lax",
-          "desc": "For a small trusted team behind auth, VPN, or a private reverse proxy."
+          "label": "Family / Semi-Lax",
+          "desc": "For a small trusted set of people behind auth, VPN, or a private reverse proxy."
         },
         "public-web": {
           "label": "Public Web Instance",
@@ -290,6 +290,7 @@
       "test-testing": "Testing…",
       "test-request-failed": "Request failed",
       "field-remove-aria": "Remove",
+      "field-edit-aria": "Edit",
       "field-add": "Add"
     },
     "confirm": {

--- a/src/locales/fr-FR.json
+++ b/src/locales/fr-FR.json
@@ -276,6 +276,7 @@
       "test-testing": "Test en cours…",
       "test-request-failed": "Échec de la requête",
       "field-remove-aria": "Retirer",
+      "field-edit-aria": "Modifier",
       "field-add": "Ajouter"
     },
     "confirm": {

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -270,6 +270,7 @@
       "test-testing": "בודק...",
       "test-request-failed": "הבקשה נכשלה",
       "field-remove-aria": "הסר",
+      "field-edit-aria": "ערוך",
       "field-add": "הוסף"
     },
     "confirm": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -270,6 +270,7 @@
       "test-testing": "Verifica in corso…",
       "test-request-failed": "Richiesta non riuscita",
       "field-remove-aria": "Rimuovi",
+      "field-edit-aria": "Modifica",
       "field-add": "Aggiungi"
     },
     "confirm": {

--- a/src/server/types/extension.ts
+++ b/src/server/types/extension.ts
@@ -56,6 +56,8 @@ export interface SettingField {
   | "toggle"
   | "textarea"
   | "select"
+  | "urllist"
+  | "list"
   | "info";
   required?: boolean;
   placeholder?: string;
@@ -66,6 +68,8 @@ export interface SettingField {
   default?: string;
   advanced?: boolean;
   visibleWhen?: { key: string; equals: string };
+  itemSchema?: SettingField[];
+  addLabel?: string;
 }
 
 export interface PluginManifest {

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -359,6 +359,97 @@
   }
 }
 
+.ext-list {
+  display: flex;
+  flex-direction: column;
+  gap: $space-2;
+
+  &-rows {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+    max-height: 50vh;
+    overflow-y: auto;
+  }
+
+  &-row {
+    background: var(--bg);
+    border-radius: $radius-md;
+    padding: $space-2 $space-3;
+  }
+
+  &-row-head {
+    align-items: center;
+    display: flex;
+    gap: $space-2;
+  }
+
+  &-row-summary {
+    flex: 1;
+    color: var(--text-primary);
+    font-size: $font-size-small;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  &-row-edit,
+  &-row-remove {
+    align-items: center;
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 1.1rem;
+    height: 1.75rem;
+    justify-content: center;
+    line-height: 1;
+    padding: 0;
+    width: 1.75rem;
+    flex-shrink: 0;
+
+    &:hover {
+      color: var(--text-primary);
+    }
+  }
+
+  &-row-editor {
+    display: flex;
+    flex-direction: column;
+    gap: $space-3;
+    margin-top: $space-3;
+
+    &[hidden] {
+      display: none;
+    }
+  }
+
+  &-sub {
+    display: flex;
+    flex-direction: column;
+    gap: $space-2;
+
+    &--toggle {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+
+  &-sub-label {
+    color: var(--text-secondary);
+    font-size: $font-size-small;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  &-add {
+    align-self: flex-start;
+  }
+}
+
 .ext-advanced-section {
   margin-top: $space-2;
   padding-top: $space-3;

--- a/tests/public/list-field-data.test.ts
+++ b/tests/public/list-field-data.test.ts
@@ -69,6 +69,23 @@ describe("public/list-field-data", () => {
     ).toEqual([{ mode: "a" }, { mode: "b" }]);
   });
 
+  test("serializeRows keeps rows with empty text but populated select", () => {
+    const mixedSchema: SettingField[] = [
+      { key: "name", label: "Name", type: "text" },
+      { key: "mode", label: "Mode", type: "select", options: ["a", "b"] },
+    ];
+    const rows = [
+      { name: "GitHub", mode: "a" },
+      { name: "", mode: "b" },
+    ];
+    expect(
+      parseListValue(serializeRows(rows, mixedSchema), mixedSchema),
+    ).toEqual([
+      { name: "GitHub", mode: "a" },
+      { name: "", mode: "b" },
+    ]);
+  });
+
   test("rowSummary ignores toggle and info fields", () => {
     const schema: SettingField[] = [
       { key: "note", label: "Note", type: "info", default: "static" },

--- a/tests/public/list-field-data.test.ts
+++ b/tests/public/list-field-data.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseListValue,
+  serializeRows,
+  defaultListRow,
+  rowSummary,
+} from "../../src/client/modules/modals/settings-modal/list-field-data";
+import type { SettingField } from "../../src/client/types";
+
+const itemSchema: SettingField[] = [
+  { key: "name", label: "Name", type: "text" },
+  { key: "shortcut", label: "Shortcut", type: "text" },
+  { key: "openBase", label: "Open base", type: "toggle", default: "true" },
+];
+
+describe("public/list-field-data", () => {
+  test("parseListValue parses a JSON array of objects", () => {
+    const raw = JSON.stringify([
+      { name: "GitHub", shortcut: "gh", openBase: true },
+      { name: "YouTube", shortcut: "yt" },
+    ]);
+    const rows = parseListValue(raw, itemSchema);
+    expect(rows).toEqual([
+      { name: "GitHub", shortcut: "gh", openBase: "true" },
+      { name: "YouTube", shortcut: "yt", openBase: "false" },
+    ]);
+  });
+
+  test("parseListValue returns [] for empty, malformed, or non-array input", () => {
+    expect(parseListValue(undefined, itemSchema)).toEqual([]);
+    expect(parseListValue("", itemSchema)).toEqual([]);
+    expect(parseListValue("not json", itemSchema)).toEqual([]);
+    expect(parseListValue('{"a":1}', itemSchema)).toEqual([]);
+  });
+
+  test("parseListValue tolerates extra and missing keys", () => {
+    const raw = JSON.stringify([{ shortcut: "w", extra: "ignored" }]);
+    const rows = parseListValue(raw, itemSchema);
+    expect(rows).toEqual([{ name: "", shortcut: "w", openBase: "false" }]);
+  });
+
+  test("serializeRows drops rows with no text content and round-trips", () => {
+    const rows = [
+      { name: "GitHub", shortcut: "gh", openBase: "true" },
+      { name: "", shortcut: "", openBase: "true" },
+    ];
+    const serialized = serializeRows(rows, itemSchema);
+    expect(parseListValue(serialized, itemSchema)).toEqual([
+      { name: "GitHub", shortcut: "gh", openBase: "true" },
+    ]);
+  });
+
+  test("serializeRows keeps rows when schema has no fillable text fields", () => {
+    const toggleSchema: SettingField[] = [
+      { key: "enabled", label: "Enabled", type: "toggle", default: "true" },
+    ];
+    const rows = [{ enabled: "true" }, { enabled: "false" }];
+    expect(parseListValue(serializeRows(rows, toggleSchema), toggleSchema)).toEqual([
+      { enabled: "true" },
+      { enabled: "false" },
+    ]);
+
+    const selectSchema: SettingField[] = [
+      { key: "mode", label: "Mode", type: "select", options: ["a", "b"] },
+    ];
+    const selectRows = [{ mode: "a" }, { mode: "b" }];
+    expect(
+      parseListValue(serializeRows(selectRows, selectSchema), selectSchema),
+    ).toEqual([{ mode: "a" }, { mode: "b" }]);
+  });
+
+  test("rowSummary ignores toggle and info fields", () => {
+    const schema: SettingField[] = [
+      { key: "note", label: "Note", type: "info", default: "static" },
+      { key: "name", label: "Name", type: "text" },
+      { key: "on", label: "On", type: "toggle" },
+    ];
+    expect(
+      rowSummary({ note: "static", name: "GitHub", on: "true" }, schema),
+    ).toBe("GitHub");
+  });
+
+  test("defaultListRow applies schema defaults", () => {
+    expect(defaultListRow(itemSchema)).toEqual({
+      name: "",
+      shortcut: "",
+      openBase: "true",
+    });
+  });
+
+  test("rowSummary joins the first two non-toggle values", () => {
+    expect(
+      rowSummary(
+        { name: "GitHub", shortcut: "gh", openBase: "true" },
+        itemSchema,
+      ),
+    ).toBe("GitHub · gh");
+    expect(
+      rowSummary({ name: "", shortcut: "", openBase: "false" }, itemSchema),
+    ).toBe("…");
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **list** settings field type that renders a schema-driven “rows” editor in the settings modal.
  * Supports **add**, **edit/show**, and **remove** row actions with automatic **row summaries** and correct value serialization (including toggle handling).

* **Bug Fixes**
  * Improved **info** field rendering so the disabled value is shown only when it has a meaningful default.

* **Localization**
  * Updated the Server preset text to **“Family / Semi-Lax.”**
  * Added the missing edit button accessibility label in **French, Hebrew, and Italian**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->