### PR TITLE
Fix sticky header and alignment issues in settings panel

### DIFF
--- a/src/client/modules/settings/settings.ts
+++ b/src/client/modules/settings/settings.ts
@@ -193,10 +193,43 @@ function _initTabs(): void {
   }
 }
 
+function _initSettingsMainOffset(): void {
+  const main = document.querySelector<HTMLElement>(".settings-page-main");
+  const search = document.querySelector<HTMLElement>(".settings-nav-search");
+  if (!main || !search) return;
+
+  const desktop = window.matchMedia("(min-width: 768px)");
+  let frame = 0;
+
+  const sync = (): void => {
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      main.style.paddingTop = "";
+      if (!desktop.matches) return;
+      const offset = search.getBoundingClientRect().top - main.getBoundingClientRect().top;
+      main.style.paddingTop = `${Math.max(0, offset)}px`;
+    });
+  };
+
+  sync();
+  window.addEventListener("resize", sync);
+  desktop.addEventListener("change", sync);
+  window.addEventListener("load", sync, { once: true });
+  void document.fonts?.ready.then(sync);
+
+  if ("ResizeObserver" in window) {
+    const observer = new ResizeObserver(sync);
+    observer.observe(search);
+    const header = document.querySelector<HTMLElement>(".settings-page-header");
+    if (header) observer.observe(header);
+  }
+}
+
 async function _initSettings(): Promise<void> {
   void initTheme();
   initInstallPrompt();
   _initTabs();
+  _initSettingsMainOffset();
   void initGeneralTab();
   void initServerTab(getStoredToken);
   void initShortcutsTab(getStoredToken);

--- a/src/public/settings.html
+++ b/src/public/settings.html
@@ -42,16 +42,15 @@
   </head>
   <body class="settings-page-body">
     <div class="settings-page">
-      <header class="settings-page-header">
-        <a href="/" class="settings-page-back">
-          <i class="fa-solid fa-arrow-left fa-xl"></i>
-          {{t:settings-page.back}}
-        </a>
-        <h1 class="settings-page-title">{{t:settings-page.page-title}}</h1>
-      </header>
-
       <div class="settings-layout">
         <div class="settings-sidebar">
+          <header class="settings-page-header">
+            <a href="/" class="settings-page-back">
+              <i class="fa-solid fa-arrow-left fa-xl"></i>
+              {{t:settings-page.back}}
+            </a>
+            <h1 class="settings-page-title">{{t:settings-page.page-title}}</h1>
+          </header>
           <div
             class="settings-nav-search degoog-search-bar degoog-search-bar--square-advanced"
           >

--- a/src/styles/components/overrides/_settings.scss
+++ b/src/styles/components/overrides/_settings.scss
@@ -45,12 +45,8 @@ html:has(.settings-page-body) {
 }
 
 .settings-page-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: var(--bg);
   padding-top: clamp($space-6, 4vw, $space-8);
-  margin-bottom: $space-6;
+  padding-bottom: $space-6;
 }
 
 .settings-page-back {
@@ -100,7 +96,9 @@ html:has(.settings-page-body) {
     flex-shrink: 0;
     align-self: flex-start;
     position: sticky;
-    top: 9rem;
+    top: 0;
+    max-height: 100vh;
+    overflow-y: auto;
     margin-bottom: 0;
   }
 }
@@ -194,6 +192,10 @@ html:has(.settings-page-body) {
   flex-direction: column;
   flex: 1;
   min-width: 0;
+
+  @media (min-width: 768px) {
+    padding-top: clamp($space-6, 4vw, $space-8);
+  }
 }
 
 .settings-section {

--- a/src/styles/components/overrides/_settings.scss
+++ b/src/styles/components/overrides/_settings.scss
@@ -1,3 +1,7 @@
+html:has(.settings-page-body) {
+  scrollbar-gutter: stable;
+}
+
 .settings-page-body {
   min-height: 100vh;
 
@@ -30,7 +34,7 @@
 
 .settings-page {
   margin: 0 auto;
-  padding: clamp($space-6, 4vw, $space-8) clamp($space-5, 5vw, $space-7) clamp($space-9, 5vw, $space-10);
+  padding: 0 clamp($space-5, 5vw, $space-7) clamp($space-9, 5vw, $space-10);
   display: flex;
   flex-direction: column;
   min-height: 100vh;
@@ -41,6 +45,11 @@
 }
 
 .settings-page-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--bg);
+  padding-top: clamp($space-6, 4vw, $space-8);
   margin-bottom: $space-6;
 }
 
@@ -91,7 +100,7 @@
     flex-shrink: 0;
     align-self: flex-start;
     position: sticky;
-    top: $space-8;
+    top: 9rem;
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
## Fixed
- Bug where left bar would flicker when changing tabs
- Bug where some items in the left bar weren't sticky

##  Changed
- Main section scroll behavior

https://github.com/user-attachments/assets/c0058be3-aefe-4177-824b-3f12191417f8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Reorganized the settings page header within the sidebar/layout to improve visual hierarchy and consistency.
  * Improved desktop sidebar behavior with more reliable sticky positioning and smoother vertical scrolling.
  * Refined spacing/padding across the settings interface, including more stable scrollbar behavior and better alignment of the main content with the header/search area across screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->