### PR TITLE
Improve PostgreSQL pruning performance

### DIFF
--- a/src/server/indexer/adapters/postgres/adapter.ts
+++ b/src/server/indexer/adapters/postgres/adapter.ts
@@ -12,6 +12,7 @@ import { safeSlug } from "../../shared/safe-type";
 import { logger } from "../../../utils/logger";
 import { initPgSchema } from "./schema";
 import { runPgPrune } from "./prune";
+import { createHash } from "crypto";
 
 const IMPORT_BATCH_SIZE = 500;
 
@@ -52,26 +53,35 @@ export class PgAdapter implements IndexerAdapter {
 
     await this._sql.begin(async (tx) => initPgSchema(tx, schema));
 
-    const indexName = `idx_${schema}_hits_url_id`;
+    // PostgreSQL identifiers are limited to 63 bytes.
+    const hash = createHash("sha1").update(schema).digest("hex").slice(0, 8);
+    const prefix = "idx_";
+    const suffix = "_hits_url_id";
+    const maxSchemaLen = 63 - prefix.length - suffix.length - hash.length - 1;
+
+    const indexName = `${prefix}${schema.slice(0, maxSchemaLen)}_${hash}${suffix}`;
 
     const [index] = await this._sql<{ indisvalid: boolean }[]>`
       SELECT i.indisvalid
       FROM pg_class c
       JOIN pg_namespace n ON n.oid = c.relnamespace
       JOIN pg_index i ON i.indexrelid = c.oid
-      WHERE c.relname = ${indexName}
+      WHERE c.relkind = 'i'
+        AND c.relname = ${indexName}
         AND n.nspname = ${schema}
     `;
 
     if (index && !index.indisvalid) {
       await this._sql`
-        DROP INDEX CONCURRENTLY ${this._sql(schema)}.${this._sql(indexName)}
+        DROP INDEX CONCURRENTLY IF EXISTS
+        ${this._sql(schema)}.${this._sql(indexName)}
       `;
     }
 
     if (!index || !index.indisvalid) {
       await this._sql`
-        CREATE INDEX CONCURRENTLY ${this._sql(indexName)}
+        CREATE INDEX CONCURRENTLY IF NOT EXISTS
+        ${this._sql(indexName)}
         ON ${this._sql(schema)}.query_hits (url_id)
       `;
     }

--- a/src/server/indexer/adapters/postgres/adapter.ts
+++ b/src/server/indexer/adapters/postgres/adapter.ts
@@ -52,10 +52,29 @@ export class PgAdapter implements IndexerAdapter {
 
     await this._sql.begin(async (tx) => initPgSchema(tx, schema));
 
-    await this._sql`
-      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${this._sql(`idx_${schema}_hits_url_id`)}
-      ON ${this._sql(schema)}.query_hits (url_id)
+    const indexName = `idx_${schema}_hits_url_id`;
+
+    const [index] = await this._sql<{ indisvalid: boolean }[]>`
+      SELECT i.indisvalid
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = ${indexName}
+        AND n.nspname = ${schema}
     `;
+
+    if (index && !index.indisvalid) {
+      await this._sql`
+        DROP INDEX CONCURRENTLY ${this._sql(schema)}.${this._sql(indexName)}
+      `;
+    }
+
+    if (!index || !index.indisvalid) {
+      await this._sql`
+        CREATE INDEX CONCURRENTLY ${this._sql(indexName)}
+        ON ${this._sql(schema)}.query_hits (url_id)
+      `;
+    }
 
     this._types.add(schema);
   }
@@ -364,19 +383,19 @@ export class PgAdapter implements IndexerAdapter {
     const schema = safeSlug(type);
 
     await this._sql.begin(async (tx) => {
+      const deleted = await tx<{ url_id: number }[]>`
+        DELETE FROM ${tx(schema)}.query_hits
+        WHERE id = ANY(${ids})
+        RETURNING url_id
+      `;
+
+      const urlIds = [...new Set(deleted.map((r) => r.url_id))];
+
+      if (urlIds.length === 0) return;
+
       await tx`
-        WITH deleted_hits AS (
-          DELETE FROM ${tx(schema)}.query_hits
-          WHERE id = ANY(${ids})
-          RETURNING url_id
-        ),
-        affected_urls AS (
-          SELECT DISTINCT url_id
-          FROM deleted_hits
-        )
         DELETE FROM ${tx(schema)}.urls u
-        USING affected_urls a
-        WHERE u.id = a.url_id
+        WHERE u.id = ANY(${urlIds})
           AND NOT EXISTS (
             SELECT 1
             FROM ${tx(schema)}.query_hits h

--- a/src/server/indexer/adapters/postgres/adapter.ts
+++ b/src/server/indexer/adapters/postgres/adapter.ts
@@ -1,5 +1,11 @@
 import postgres from "postgres";
-import type { IndexerAdapter, UrlRow, HitRow, TypeCounts, ExportRow } from "../../types/adapter";
+import type {
+  IndexerAdapter,
+  UrlRow,
+  HitRow,
+  TypeCounts,
+  ExportRow,
+} from "../../types/adapter";
 import type { IndexRow } from "../../recorders";
 import type { IndexerConfig } from "../../types/config";
 import { safeSlug } from "../../shared/safe-type";
@@ -30,7 +36,10 @@ export class PgAdapter implements IndexerAdapter {
           AND table_schema NOT IN ('public', 'information_schema', 'pg_catalog')
       `;
       for (const row of rows) this._types.add(row.table_schema);
-      logger.info("indexer", `postgres adapter booted, found types: [${Array.from(this._types).join(", ")}]`);
+      logger.info(
+        "indexer",
+        `postgres adapter booted, found types: [${Array.from(this._types).join(", ")}]`,
+      );
     } catch (err) {
       logger.error("indexer", "postgres adapter boot failed", err);
       throw err;
@@ -40,7 +49,14 @@ export class PgAdapter implements IndexerAdapter {
   async open(type: string): Promise<void> {
     const schema = safeSlug(type);
     if (this._types.has(schema)) return;
+
     await this._sql.begin(async (tx) => initPgSchema(tx, schema));
+
+    await this._sql`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS ${this._sql(`idx_${schema}_hits_url_id`)}
+      ON ${this._sql(schema)}.query_hits (url_id)
+    `;
+
     this._types.add(schema);
   }
 
@@ -56,7 +72,7 @@ export class PgAdapter implements IndexerAdapter {
     }
   }
 
-  async checkpoint(_type: string): Promise<void> { }
+  async checkpoint(_type: string): Promise<void> {}
 
   async writeBatch(type: string, rows: IndexRow[], now: number): Promise<void> {
     const schema = safeSlug(type);
@@ -98,7 +114,10 @@ export class PgAdapter implements IndexerAdapter {
     });
   }
 
-  async importRows(type: string, rows: ExportRow[]): Promise<{ urls: number; hits: number }> {
+  async importRows(
+    type: string,
+    rows: ExportRow[],
+  ): Promise<{ urls: number; hits: number }> {
     const schema = safeSlug(type);
     await this.open(type);
     let urlsInserted = 0;
@@ -123,9 +142,12 @@ export class PgAdapter implements IndexerAdapter {
           `;
           if (urlRows.length > 0) urlsInserted++;
 
-          const [existingUrl] = urlRows.length > 0
-            ? urlRows
-            : await tx<{ id: number }[]>`SELECT id FROM ${tx(schema)}.urls WHERE url_norm = ${row.url_norm}`;
+          const [existingUrl] =
+            urlRows.length > 0
+              ? urlRows
+              : await tx<
+                  { id: number }[]
+                >`SELECT id FROM ${tx(schema)}.urls WHERE url_norm = ${row.url_norm}`;
 
           if (!existingUrl) continue;
 
@@ -145,7 +167,12 @@ export class PgAdapter implements IndexerAdapter {
     return { urls: urlsInserted, hits: hitsInserted };
   }
 
-  async queryExact(type: string, queryNorm: string, limit: number, offset = 0): Promise<UrlRow[]> {
+  async queryExact(
+    type: string,
+    queryNorm: string,
+    limit: number,
+    offset = 0,
+  ): Promise<UrlRow[]> {
     const schema = safeSlug(type);
     try {
       return await this._sql<UrlRow[]>`
@@ -163,7 +190,12 @@ export class PgAdapter implements IndexerAdapter {
     }
   }
 
-  async queryFuzzy(type: string, queryNorm: string, limit: number, offset = 0): Promise<UrlRow[]> {
+  async queryFuzzy(
+    type: string,
+    queryNorm: string,
+    limit: number,
+    offset = 0,
+  ): Promise<UrlRow[]> {
     const schema = safeSlug(type);
     const pgExpr = queryNorm
       .split(/\s+/)
@@ -328,12 +360,28 @@ export class PgAdapter implements IndexerAdapter {
 
   async deleteHitsForType(type: string, ids: number[]): Promise<void> {
     if (ids.length === 0) return;
+
     const schema = safeSlug(type);
+
     await this._sql.begin(async (tx) => {
-      await tx`DELETE FROM ${tx(schema)}.query_hits WHERE id = ANY(${ids})`;
       await tx`
-        DELETE FROM ${tx(schema)}.urls
-        WHERE id NOT IN (SELECT url_id FROM ${tx(schema)}.query_hits)
+        WITH deleted_hits AS (
+          DELETE FROM ${tx(schema)}.query_hits
+          WHERE id = ANY(${ids})
+          RETURNING url_id
+        ),
+        affected_urls AS (
+          SELECT DISTINCT url_id
+          FROM deleted_hits
+        )
+        DELETE FROM ${tx(schema)}.urls u
+        USING affected_urls a
+        WHERE u.id = a.url_id
+          AND NOT EXISTS (
+            SELECT 1
+            FROM ${tx(schema)}.query_hits h
+            WHERE h.url_id = u.id
+          )
       `;
     });
   }

--- a/src/server/indexer/adapters/postgres/prune.ts
+++ b/src/server/indexer/adapters/postgres/prune.ts
@@ -25,42 +25,35 @@ export const runPgPrune = async (
   };
 
   const deleteOldHitsBatch = async (cutoff: number): Promise<number> => {
-    const [row] = await sql.begin(async (tx) => {
-      const rows = await tx<{ hits_deleted: number }[]>`
-        WITH doomed AS (
-          SELECT id, url_id
+    return await sql.begin(async (tx) => {
+      const deletedHits = await tx<{ url_id: number }[]>`
+        DELETE FROM ${tx(schema)}.query_hits
+        WHERE id IN (
+          SELECT id
           FROM ${tx(schema)}.query_hits
           WHERE last_seen < ${cutoff}
           ORDER BY last_seen ASC, id ASC
           LIMIT ${BATCH_SIZE}
-        ),
-        deleted_hits AS (
-          DELETE FROM ${tx(schema)}.query_hits h
-          USING doomed d
-          WHERE h.id = d.id
-          RETURNING h.url_id
-        ),
-        affected_urls AS (
-          SELECT DISTINCT url_id
-          FROM deleted_hits
-        ),
-        deleted_urls AS (
+        )
+        RETURNING url_id
+      `;
+
+      const urlIds = [...new Set(deletedHits.map((row) => row.url_id))];
+
+      if (urlIds.length > 0) {
+        await tx`
           DELETE FROM ${tx(schema)}.urls u
-          USING affected_urls a
-          WHERE u.id = a.url_id
+          WHERE u.id = ANY(${urlIds})
             AND NOT EXISTS (
               SELECT 1
               FROM ${tx(schema)}.query_hits h
               WHERE h.url_id = u.id
             )
-          RETURNING u.id
-        )
-        SELECT (SELECT COUNT(*) FROM deleted_hits)::int AS hits_deleted
-      `;
-      return rows;
-    });
+        `;
+      }
 
-    return Number(row?.hits_deleted ?? 0);
+      return deletedHits.length;
+    });
   };
 
   const deleteOldHitsBatchByCount = async (limit: number): Promise<number> => {

--- a/src/server/indexer/adapters/postgres/prune.ts
+++ b/src/server/indexer/adapters/postgres/prune.ts
@@ -1,44 +1,160 @@
 import type postgres from "postgres";
 import type { IndexerConfig } from "../../types/config";
 
+const BATCH_SIZE = 1000;
+
 export const runPgPrune = async (
   sql: ReturnType<typeof postgres>,
   schema: string,
   cfg: IndexerConfig,
 ): Promise<void> => {
-  await sql.begin(async (tx) => {
-    if (cfg.maxAgeDays > 0) {
-      const cutoff = Date.now() - cfg.maxAgeDays * 86_400_000;
-      await tx`DELETE FROM ${tx(schema)}.query_hits WHERE last_seen < ${cutoff}`;
-      await tx`
-        DELETE FROM ${tx(schema)}.urls
-        WHERE id NOT IN (SELECT url_id FROM ${tx(schema)}.query_hits)
-      `;
-    }
-    if (!cfg.pruneEnabled) return;
-    if (cfg.maxHits > 0) {
-      await tx`
-        DELETE FROM ${tx(schema)}.query_hits
-        WHERE id IN (
-          SELECT id FROM ${tx(schema)}.query_hits
-          ORDER BY last_seen ASC
-          LIMIT GREATEST(0, (SELECT COUNT(*) FROM ${tx(schema)}.query_hits) - ${cfg.maxHits})
+  const countHits = async (): Promise<number> => {
+    const [row] = await sql<{ c: string }[]>`
+      SELECT COUNT(*)::bigint AS c
+      FROM ${sql(schema)}.query_hits
+    `;
+    return Number(row?.c ?? 0);
+  };
+
+  const countUrls = async (): Promise<number> => {
+    const [row] = await sql<{ c: string }[]>`
+      SELECT COUNT(*)::bigint AS c
+      FROM ${sql(schema)}.urls
+    `;
+    return Number(row?.c ?? 0);
+  };
+
+  const deleteOldHitsBatch = async (cutoff: number): Promise<number> => {
+    const [row] = await sql.begin(async (tx) => {
+      const rows = await tx<{ hits_deleted: number }[]>`
+        WITH doomed AS (
+          SELECT id, url_id
+          FROM ${tx(schema)}.query_hits
+          WHERE last_seen < ${cutoff}
+          ORDER BY last_seen ASC, id ASC
+          LIMIT ${BATCH_SIZE}
+        ),
+        deleted_hits AS (
+          DELETE FROM ${tx(schema)}.query_hits h
+          USING doomed d
+          WHERE h.id = d.id
+          RETURNING h.url_id
+        ),
+        affected_urls AS (
+          SELECT DISTINCT url_id
+          FROM deleted_hits
+        ),
+        deleted_urls AS (
+          DELETE FROM ${tx(schema)}.urls u
+          USING affected_urls a
+          WHERE u.id = a.url_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${tx(schema)}.query_hits h
+              WHERE h.url_id = u.id
+            )
+          RETURNING u.id
         )
+        SELECT (SELECT COUNT(*) FROM deleted_hits)::int AS hits_deleted
       `;
-      await tx`
-        DELETE FROM ${tx(schema)}.urls
-        WHERE id NOT IN (SELECT url_id FROM ${tx(schema)}.query_hits)
-      `;
-    }
-    if (cfg.maxUrls > 0) {
-      await tx`
-        DELETE FROM ${tx(schema)}.urls
-        WHERE id IN (
-          SELECT id FROM ${tx(schema)}.urls
-          ORDER BY last_seen ASC
-          LIMIT GREATEST(0, (SELECT COUNT(*) FROM ${tx(schema)}.urls) - ${cfg.maxUrls})
+      return rows;
+    });
+
+    return Number(row?.hits_deleted ?? 0);
+  };
+
+  const deleteOldHitsBatchByCount = async (limit: number): Promise<number> => {
+    const [row] = await sql.begin(async (tx) => {
+      const rows = await tx<{ hits_deleted: number }[]>`
+        WITH doomed AS (
+          SELECT id, url_id
+          FROM ${tx(schema)}.query_hits
+          ORDER BY last_seen ASC, id ASC
+          LIMIT ${limit}
+        ),
+        deleted_hits AS (
+          DELETE FROM ${tx(schema)}.query_hits h
+          USING doomed d
+          WHERE h.id = d.id
+          RETURNING h.url_id
+        ),
+        affected_urls AS (
+          SELECT DISTINCT url_id
+          FROM deleted_hits
+        ),
+        deleted_urls AS (
+          DELETE FROM ${tx(schema)}.urls u
+          USING affected_urls a
+          WHERE u.id = a.url_id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM ${tx(schema)}.query_hits h
+              WHERE h.url_id = u.id
+            )
+          RETURNING u.id
         )
+        SELECT (SELECT COUNT(*) FROM deleted_hits)::int AS hits_deleted
       `;
+      return rows;
+    });
+
+    return Number(row?.hits_deleted ?? 0);
+  };
+
+  const deleteOldUrlsBatch = async (limit: number): Promise<number> => {
+    const [row] = await sql.begin(async (tx) => {
+      const rows = await tx<{ urls_deleted: number }[]>`
+        WITH doomed AS (
+          SELECT id
+          FROM ${tx(schema)}.urls
+          ORDER BY last_seen ASC, id ASC
+          LIMIT ${limit}
+        ),
+        deleted_urls AS (
+          DELETE FROM ${tx(schema)}.urls u
+          USING doomed d
+          WHERE u.id = d.id
+          RETURNING u.id
+        )
+        SELECT (SELECT COUNT(*) FROM deleted_urls)::int AS urls_deleted
+      `;
+      return rows;
+    });
+
+    return Number(row?.urls_deleted ?? 0);
+  };
+
+  if (cfg.maxAgeDays > 0) {
+    const cutoff = Date.now() - cfg.maxAgeDays * 86_400_000;
+
+    while (true) {
+      const deleted = await deleteOldHitsBatch(cutoff);
+      if (deleted === 0) break;
+      if (deleted < BATCH_SIZE) break;
     }
-  });
+  }
+
+  if (!cfg.pruneEnabled) return;
+
+  if (cfg.maxHits > 0) {
+    let remainingHits = await countHits();
+
+    while (remainingHits > cfg.maxHits) {
+      const toDelete = Math.min(BATCH_SIZE, remainingHits - cfg.maxHits);
+      const deleted = await deleteOldHitsBatchByCount(toDelete);
+      if (deleted === 0) break;
+      remainingHits -= deleted;
+    }
+  }
+
+  if (cfg.maxUrls > 0) {
+    let remainingUrls = await countUrls();
+
+    while (remainingUrls > cfg.maxUrls) {
+      const toDelete = Math.min(BATCH_SIZE, remainingUrls - cfg.maxUrls);
+      const deleted = await deleteOldUrlsBatch(toDelete);
+      if (deleted === 0) break;
+      remainingUrls -= deleted;
+    }
+  }
 };


### PR DESCRIPTION
The previous implementation performed full-table orphan scans after deleting query hits. On databases with over one million rows, this resulted in long-running delete operations, high CPU usage, and large transactions.

The new approach only checks URLs that were actually affected by the deleted query hits and processes large prune operations in small batches, significantly reducing database load while preserving the existing behavior.

This was made with AI, I am really sorry if it's a waste of your time, just wanted to see if an LLM can fix it :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved background pruning now processes deletions in smaller batches, providing more stable performance on large datasets (including max-age, max-hit, and max-URL limits).
  * Automatically ensures the query-hit index is present and valid for each content type to keep hit lookup efficient.

* **Bug Fixes**
  * Deleting hits now removes URLs only when they no longer have any remaining hits, preventing accidental orphan removal during hit cleanup.
  * Pruning limit enforcement is now more consistent through repeatable batch-based processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->