### PR TITLE
Add store-wide mutex and progress streaming for store updates

### DIFF
--- a/src/client/settings/store/handlers.ts
+++ b/src/client/settings/store/handlers.ts
@@ -56,18 +56,22 @@ export async function handleRefresh(
   render: () => void,
 ): Promise<void> {
   setRepoPhase(container, url, "Refreshing", "start");
-  const res = await fetch(`${getBase()}/api/store/repos/refresh`, {
-    method: "POST",
-    headers: jsonHeaders(getToken),
-    body: JSON.stringify({ url }),
-  });
-  if (!res.ok) {
-    setRepoPhase(container, url, "Refreshing", "failed");
-    return;
+  try {
+    const res = await fetch(`${getBase()}/api/store/repos/refresh`, {
+      method: "POST",
+      headers: jsonHeaders(getToken),
+      body: JSON.stringify({ url }),
+    });
+    if (!res.ok) {
+      setRepoPhase(container, url, "Refreshing", "failed");
+      return;
+    }
+    setRepoPhase(container, url, "Refreshing", "ok");
+    await refreshAndRender();
+    void loadReposStatus().then(() => render());
+  } catch {
+    setRepoPhase(container, url, "Refreshing", "failed", "Network error");
   }
-  setRepoPhase(container, url, "Refreshing", "ok");
-  await refreshAndRender();
-  void loadReposStatus().then(() => render());
 }
 
 export async function handleRemove(

--- a/src/client/settings/store/handlers.ts
+++ b/src/client/settings/store/handlers.ts
@@ -2,6 +2,12 @@ import type { RepoInfo } from "../../types/store-tab";
 import { jsonHeaders } from "../../utils/request";
 import { confirmModal } from "../../modules/modals/confirm-modal/confirm";
 import { getBase } from "../../utils/base-url";
+import {
+  setItemPhase,
+  setRepoPhase,
+  streamRefreshAll,
+  streamUpdateAll,
+} from "./progress";
 
 export function showError(el: HTMLElement | null, msg: string): void {
   if (!el) return;
@@ -42,18 +48,24 @@ export async function handleAddRepo(
 }
 
 export async function handleRefresh(
+  container: HTMLElement,
   url: string,
   getToken: () => string | null,
   refreshAndRender: () => Promise<void>,
   loadReposStatus: () => Promise<void>,
   render: () => void,
 ): Promise<void> {
+  setRepoPhase(container, url, "Refreshing", "start");
   const res = await fetch(`${getBase()}/api/store/repos/refresh`, {
     method: "POST",
     headers: jsonHeaders(getToken),
     body: JSON.stringify({ url }),
   });
-  if (!res.ok) return;
+  if (!res.ok) {
+    setRepoPhase(container, url, "Refreshing", "failed");
+    return;
+  }
+  setRepoPhase(container, url, "Refreshing", "ok");
   await refreshAndRender();
   void loadReposStatus().then(() => render());
 }
@@ -80,12 +92,14 @@ export async function handleRemove(
 }
 
 export async function handleInstall(
+  container: HTMLElement,
   btn: HTMLButtonElement,
   getToken: () => string | null,
   loadItems: () => Promise<void>,
   render: () => void,
 ): Promise<void> {
   const { repoUrl, itemPath, type } = btn.dataset;
+  if (!repoUrl || !itemPath || !type) return;
   if (
     type === "plugin" &&
     !(await confirmModal({
@@ -95,7 +109,9 @@ export async function handleInstall(
     }))
   )
     return;
+  const key = { repoUrl, itemPath, type };
   btn.disabled = true;
+  setItemPhase(container, key, "Installing", "start");
   try {
     const res = await fetch(`${getBase()}/api/store/install`, {
       method: "POST",
@@ -103,14 +119,16 @@ export async function handleInstall(
       body: JSON.stringify({ repoUrl, itemPath, type }),
     });
     const data = (await res.json()) as { error?: string };
-    if (!res.ok) alert(data.error || "Install failed");
-    else {
-      await loadItems();
-      render();
-      window.dispatchEvent(new CustomEvent("extensions-saved"));
+    if (!res.ok) {
+      setItemPhase(container, key, "Installing", "failed", data.error);
+      return;
     }
+    setItemPhase(container, key, "Installing", "ok");
+    await loadItems();
+    render();
+    window.dispatchEvent(new CustomEvent("extensions-saved"));
   } catch {
-    alert("Network error");
+    setItemPhase(container, key, "Installing", "failed", "Network error");
   } finally {
     btn.disabled = false;
   }
@@ -187,13 +205,17 @@ export async function handleDeleteUntracked(
 }
 
 export async function handleUpdate(
+  container: HTMLElement,
   btn: HTMLButtonElement,
   getToken: () => string | null,
   loadItems: () => Promise<void>,
   render: () => void,
 ): Promise<void> {
   const { repoUrl, itemPath, type } = btn.dataset;
+  if (!repoUrl || !itemPath || !type) return;
+  const key = { repoUrl, itemPath, type };
   btn.disabled = true;
+  setItemPhase(container, key, "Updating", "start");
   try {
     const res = await fetch(`${getBase()}/api/store/update`, {
       method: "POST",
@@ -201,14 +223,16 @@ export async function handleUpdate(
       body: JSON.stringify({ repoUrl, itemPath, type }),
     });
     const data = (await res.json()) as { error?: string };
-    if (!res.ok) alert(data.error || "Update failed");
-    else {
-      await loadItems();
-      render();
-      window.dispatchEvent(new CustomEvent("extensions-saved"));
+    if (!res.ok) {
+      setItemPhase(container, key, "Updating", "failed", data.error);
+      return;
     }
+    setItemPhase(container, key, "Updating", "ok");
+    await loadItems();
+    render();
+    window.dispatchEvent(new CustomEvent("extensions-saved"));
   } catch {
-    alert("Network error");
+    setItemPhase(container, key, "Updating", "failed", "Network error");
   } finally {
     btn.disabled = false;
   }
@@ -225,19 +249,10 @@ export async function handleUpdateAll(
   );
   if (btn) btn.disabled = true;
   try {
-    const res = await fetch(`${getBase()}/api/store/update-all`, {
-      method: "POST",
-      headers: jsonHeaders(getToken),
-    });
-    const data = (await res.json()) as { error?: string; updated?: number };
-    if (!res.ok) alert(data.error || "Update failed");
-    else {
-      await loadItems();
-      render();
-      window.dispatchEvent(new CustomEvent("extensions-saved"));
-    }
-  } catch {
-    alert("Network error");
+    await streamUpdateAll(container, getToken);
+    await loadItems();
+    render();
+    window.dispatchEvent(new CustomEvent("extensions-saved"));
   } finally {
     if (btn) btn.disabled = false;
   }
@@ -255,11 +270,7 @@ export async function handleRefreshAll(
   );
   if (btn) btn.disabled = true;
   try {
-    await fetch(`${getBase()}/api/store/repos/refresh`, {
-      method: "POST",
-      headers: jsonHeaders(getToken),
-      body: JSON.stringify({}),
-    });
+    await streamRefreshAll(container, getToken);
     await refreshAndRender();
     void loadReposStatus().then(() => render());
   } finally {

--- a/src/client/settings/store/progress.ts
+++ b/src/client/settings/store/progress.ts
@@ -1,0 +1,171 @@
+import { getBase } from "../../utils/base-url";
+
+type Phase = "start" | "ok" | "failed";
+
+interface StoreStreamEvent {
+  repoUrl?: string;
+  itemPath?: string;
+  type?: string;
+  url?: string;
+  name?: string;
+  i: number;
+  total: number;
+  phase: Phase;
+  error?: string;
+}
+
+export interface ItemKey {
+  repoUrl: string;
+  itemPath: string;
+  type: string;
+}
+
+const esc = (v: string): string => v.replace(/"/g, '\\"');
+
+function itemTargets(container: HTMLElement, key: ItemKey): HTMLElement[] {
+  const attr = `[data-repo-url="${esc(key.repoUrl)}"][data-item-path="${esc(key.itemPath)}"][data-type="${esc(key.type)}"]`;
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      `.store-card${attr}, .store-updates-row${attr}`,
+    ),
+  );
+}
+
+function repoTargets(container: HTMLElement, url: string): HTMLElement[] {
+  const attr = `[data-url="${esc(url)}"]`;
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      `.store-repo-item${attr}, .store-repo-detail${attr}`,
+    ),
+  );
+}
+
+function ensureOverlay(el: HTMLElement): HTMLElement {
+  let overlay = el.querySelector<HTMLElement>(":scope > .store-progress");
+  if (!overlay) {
+    overlay = document.createElement("div");
+    overlay.className = "store-progress";
+    overlay.innerHTML = `
+      <span class="store-progress-label"></span>
+      <span class="store-progress-bar"><span class="store-progress-bar-fill"></span></span>`;
+    el.appendChild(overlay);
+  }
+  return overlay;
+}
+
+function applyPhase(
+  els: HTMLElement[],
+  verb: string,
+  phase: Phase,
+  error?: string,
+): void {
+  for (const el of els) {
+    el.classList.add("store-progress-host");
+    const overlay = ensureOverlay(el);
+    const label = overlay.querySelector<HTMLElement>(".store-progress-label");
+    el.classList.remove("is-working", "is-ok", "is-failed");
+    if (phase === "start") {
+      el.classList.add("is-working");
+      if (label) label.textContent = `${verb}…`;
+    } else if (phase === "ok") {
+      el.classList.add("is-ok");
+      if (label) label.textContent = "Done";
+    } else {
+      el.classList.add("is-failed");
+      if (label) label.textContent = error || "Failed";
+    }
+  }
+}
+
+export function setItemPhase(
+  container: HTMLElement,
+  key: ItemKey,
+  verb: string,
+  phase: Phase,
+  error?: string,
+): void {
+  applyPhase(itemTargets(container, key), verb, phase, error);
+}
+
+export function setRepoPhase(
+  container: HTMLElement,
+  url: string,
+  verb: string,
+  phase: Phase,
+  error?: string,
+): void {
+  applyPhase(repoTargets(container, url), verb, phase, error);
+}
+
+function streamStoreOp(
+  path: string,
+  getToken: () => string | null,
+  event: string,
+  onEvent: (e: StoreStreamEvent) => void,
+): Promise<{ failed: number } | null> {
+  return new Promise((resolve) => {
+    const token = getToken();
+    const sep = path.includes("?") ? "&" : "?";
+    const url = `${getBase()}${path}${token ? `${sep}token=${encodeURIComponent(token)}` : ""}`;
+    const source = new EventSource(url);
+    let failed = 0;
+
+    source.addEventListener(event, (e) => {
+      const data = JSON.parse((e as MessageEvent).data) as StoreStreamEvent;
+      if (data.phase === "failed") failed++;
+      onEvent(data);
+    });
+
+    source.addEventListener("done", (e) => {
+      source.close();
+      const data = JSON.parse((e as MessageEvent).data) as { failed?: number };
+      resolve({ failed: data.failed ?? failed });
+    });
+
+    source.addEventListener("failed", () => {
+      source.close();
+      resolve(null);
+    });
+
+    source.onerror = () => {
+      source.close();
+      resolve(null);
+    };
+  });
+}
+
+export function streamUpdateAll(
+  container: HTMLElement,
+  getToken: () => string | null,
+): Promise<{ failed: number } | null> {
+  return streamStoreOp(
+    "/api/store/update-all/stream",
+    getToken,
+    "item",
+    (e) => {
+      if (!e.repoUrl || !e.itemPath || !e.type) return;
+      setItemPhase(
+        container,
+        { repoUrl: e.repoUrl, itemPath: e.itemPath, type: e.type },
+        "Updating",
+        e.phase,
+        e.error,
+      );
+    },
+  );
+}
+
+export function streamRefreshAll(
+  container: HTMLElement,
+  getToken: () => string | null,
+): Promise<{ failed: number } | null> {
+  return streamStoreOp(
+    "/api/store/repos/refresh/stream",
+    getToken,
+    "repo",
+    (e) => {
+      if (!e.url) return;
+      setRepoPhase(container, e.url, "Refreshing", e.phase, e.error);
+    },
+  );
+}

--- a/src/client/settings/store/tab.ts
+++ b/src/client/settings/store/tab.ts
@@ -413,6 +413,7 @@ export async function initStoreTab(
       }).catch(() => { });
       await loadRepos();
       await loadItems();
+      await loadReposStatus();
       render();
     })();
   } catch {

--- a/src/client/settings/store/tab.ts
+++ b/src/client/settings/store/tab.ts
@@ -237,7 +237,7 @@ export async function initStoreTab(
         .forEach((btn) => {
           btn.addEventListener(
             "click",
-            () => void handleInstall(btn, getToken, loadItems, render),
+            () => void handleInstall(container, btn, getToken, loadItems, render),
           );
         });
       grid
@@ -253,7 +253,7 @@ export async function initStoreTab(
         .forEach((btn) => {
           btn.addEventListener(
             "click",
-            () => void handleUpdate(btn, getToken, loadItems, render),
+            () => void handleUpdate(container, btn, getToken, loadItems, render),
           );
         });
       grid
@@ -317,7 +317,7 @@ export async function initStoreTab(
           .forEach((btn) => {
             btn.addEventListener(
               "click",
-              () => void handleUpdate(btn, getToken, loadItems, render),
+              () => void handleUpdate(container, btn, getToken, loadItems, render),
             );
           });
       }
@@ -376,6 +376,7 @@ export async function initStoreTab(
     );
     if (refreshBtn?.dataset.url)
       void handleRefresh(
+        container,
         refreshBtn.dataset.url,
         getToken,
         refreshAndRender,
@@ -412,7 +413,6 @@ export async function initStoreTab(
       }).catch(() => { });
       await loadRepos();
       await loadItems();
-      await loadReposStatus();
       render();
     })();
   } catch {

--- a/src/server/extensions/store/item-ops.ts
+++ b/src/server/extensions/store/item-ops.ts
@@ -16,15 +16,13 @@ import {
   writeReposData,
   getRepoByUrl,
 } from "./persistence";
-import { addRepo } from "./repo-ops";
+import { _addRepo } from "./repo-ops";
 import { STORE_TYPE_SPECS } from "./store-types";
 import { bumpPluginRegistryReload } from "../registry-factory";
-import { createMutex } from "../../utils/mutex";
+import { runStoreExclusive } from "./store-lock";
 import { makeExtID } from "../../utils/extension-id";
 import { logger } from "../../utils/logger";
 import type { ShortcutBinding, ShortcutKind } from "../../../shared/shortcuts";
-
-const _storeMutex = createMutex();
 
 function slugifyIdPart(input: string): string {
   return (
@@ -190,7 +188,7 @@ async function installDependencies(dependencies: string[]): Promise<void> {
     let repo = getRepoByUrl(data, parsed.repoUrl);
     if (!repo) {
       try {
-        repo = await addRepo(parsed.repoUrl);
+        repo = await _addRepo(parsed.repoUrl);
       } catch (err) {
         logger.warn("store:item", `failed to add repo ${parsed.repoUrl}`, err);
         continue;
@@ -496,7 +494,7 @@ export function installItem(
   itemPath: string,
   type: ExtensionStoreType,
 ): Promise<void> {
-  return _storeMutex(() => _installItem(repoUrl, itemPath, type));
+  return runStoreExclusive(() => _installItem(repoUrl, itemPath, type));
 }
 
 async function _installItem(
@@ -581,7 +579,7 @@ export function uninstallItem(
   itemPath: string,
   type: ExtensionStoreType,
 ): Promise<void> {
-  return _storeMutex(() => _uninstallItem(repoUrl, itemPath, type));
+  return runStoreExclusive(() => _uninstallItem(repoUrl, itemPath, type));
 }
 
 async function _uninstallItem(
@@ -612,7 +610,7 @@ export function updateItem(
   itemPath: string,
   type: ExtensionStoreType,
 ): Promise<void> {
-  return _storeMutex(() => _updateItem(repoUrl, itemPath, type));
+  return runStoreExclusive(() => _updateItem(repoUrl, itemPath, type));
 }
 
 async function _updateItem(
@@ -665,12 +663,50 @@ async function _updateItem(
   await reloadAfterAction(type);
 }
 
-export async function updateAllItems(): Promise<{ updated: number }> {
-  const items = await listRepoItems();
-  const updatable = items.filter((i) => i.updateAvailable);
-  for (const item of updatable)
-    await updateItem(item.repoUrl, item.path, item.type);
-  return { updated: updatable.length };
+export interface UpdateItemProgress {
+  repoUrl: string;
+  itemPath: string;
+  name: string;
+  type: ExtensionStoreType;
+  i: number;
+  total: number;
+  phase: "start" | "ok" | "failed";
+  error?: string;
+}
+
+export async function updateAllItems(
+  onProgress?: (p: UpdateItemProgress) => void,
+): Promise<{ updated: number; failed: number }> {
+  return runStoreExclusive(async () => {
+    const items = await listRepoItems();
+    const updatable = items.filter((i) => i.updateAvailable);
+    const total = updatable.length;
+    let updated = 0;
+    let failed = 0;
+    for (let idx = 0; idx < total; idx++) {
+      const item = updatable[idx];
+      const base = {
+        repoUrl: item.repoUrl,
+        itemPath: item.path,
+        name: item.name,
+        type: item.type,
+        i: idx + 1,
+        total,
+      };
+      onProgress?.({ ...base, phase: "start" });
+      try {
+        await _updateItem(item.repoUrl, item.path, item.type);
+        updated++;
+        onProgress?.({ ...base, phase: "ok" });
+      } catch (err) {
+        failed++;
+        const message = err instanceof Error ? err.message : "Update failed";
+        logger.warn("store:item", `update-all failed for ${item.name}`, err);
+        onProgress?.({ ...base, phase: "failed", error: message });
+      }
+    }
+    return { updated, failed };
+  });
 }
 
 export async function getInstalledItems(): Promise<InstalledItem[]> {
@@ -682,7 +718,7 @@ export function deleteUntracked(
   type: ExtensionStoreType,
   folderName: string,
 ): Promise<void> {
-  return _storeMutex(() => _deleteUntracked(type, folderName));
+  return runStoreExclusive(() => _deleteUntracked(type, folderName));
 }
 
 async function _deleteUntracked(

--- a/src/server/extensions/store/repo-ops.ts
+++ b/src/server/extensions/store/repo-ops.ts
@@ -1,4 +1,4 @@
-import { readFile, rm, readdir } from "fs/promises";
+import { readFile, rm } from "fs/promises";
 import { join } from "path";
 import type { RepoInfo, RepoPackageJson } from "../../types";
 import { logger } from "../../utils/logger";
@@ -25,20 +25,21 @@ const _isLockError = (stderr: string): boolean =>
     stderr,
   );
 
+const STALE_LOCK_FILES = ["shallow.lock", "index.lock"];
+
 const _cleanGitLocks = async (repoPath: string): Promise<void> => {
   const gitDir = join(repoPath, ".git");
-  try {
-    const entries = await readdir(gitDir);
-    await Promise.all(
-      entries
-        .filter((e) => e.endsWith(".lock"))
-        .map((e) =>
-          rm(join(gitDir, e), { force: true }).catch(() => {}),
+  await Promise.all(
+    STALE_LOCK_FILES.map((name) =>
+      rm(join(gitDir, name), { force: true }).catch((err) =>
+        logger.debug(
+          "store:repo",
+          `could not remove stale ${name} in ${repoPath}`,
+          err,
         ),
-    );
-  } catch (err) {
-    logger.debug("store:repo", `could not clean git locks in ${repoPath}`, err);
-  }
+      ),
+    ),
+  );
 };
 
 const probeBranch = async (url: string, branch: string): Promise<boolean> => {
@@ -89,7 +90,7 @@ const headBranch = async (repoPath: string): Promise<string> => {
 const _runFetchRef = async (
   repoPath: string,
   branch: string,
-): Promise<{ exit: number; stderr: string }> => {
+): Promise<{ exit: number; stderr: string; timedOut: boolean }> => {
   const proc = Bun.spawn(
     [
       "git",
@@ -103,23 +104,32 @@ const _runFetchRef = async (
     ],
     { stdout: "ignore", stderr: "pipe" },
   );
-  const exit = await proc.exited;
-  const stderr = exit === 0 ? "" : await new Response(proc.stderr).text();
-  return { exit, stderr };
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, FETCH_TIMEOUT_MS);
+  try {
+    const exit = await proc.exited;
+    const stderr = exit === 0 ? "" : await new Response(proc.stderr).text();
+    return { exit, stderr, timedOut };
+  } finally {
+    clearTimeout(timer);
+  }
 };
 
 const fetchRef = async (
   repoPath: string,
   branch: string,
 ): Promise<{ ok: boolean; notFound: boolean; error: string }> => {
-  let { exit, stderr } = await _runFetchRef(repoPath, branch);
-  if (exit !== 0 && _isLockError(stderr)) {
+  let { exit, stderr, timedOut } = await _runFetchRef(repoPath, branch);
+  if (exit !== 0 && !timedOut && _isLockError(stderr)) {
     logger.warn(
       "store:repo",
       `git lock detected during fetch, clearing stale locks and retrying`,
     );
     await _cleanGitLocks(repoPath);
-    ({ exit, stderr } = await _runFetchRef(repoPath, branch));
+    ({ exit, stderr, timedOut } = await _runFetchRef(repoPath, branch));
   }
   if (exit === 0) return { ok: true, notFound: false, error: "" };
   const notFound =
@@ -129,7 +139,7 @@ const fetchRef = async (
   return {
     ok: false,
     notFound,
-    error: _sanitizeGitError(stderr),
+    error: timedOut ? "Fetch timed out" : _sanitizeGitError(stderr),
   };
 };
 
@@ -380,8 +390,14 @@ async function _refreshRepo(repo: RepoInfo): Promise<void> {
 export function refreshRepo(url?: string): Promise<void> {
   return runStoreExclusive(async () => {
     const data = await readReposData();
-    const repos = url ? [getRepoByUrl(data, url)] : data.repos;
-    const toRefresh = repos.filter((r): r is RepoInfo => r != null);
+    let toRefresh: RepoInfo[];
+    if (url) {
+      const repo = getRepoByUrl(data, url);
+      if (!repo) throw new Error("Repository not found.");
+      toRefresh = [repo];
+    } else {
+      toRefresh = data.repos;
+    }
     for (const repo of toRefresh) await _refreshRepo(repo);
     await writeReposData(data);
   });
@@ -449,15 +465,7 @@ export function getReposStatus(): Promise<RepoStatus[]> {
       const repoPath = join(storeDir, repo.localPath);
       try {
         const branch = await resolveTrackedBranch(repoPath);
-        const fetched = await Promise.race([
-          fetchRef(repoPath, branch),
-          new Promise<{ ok: boolean }>((_, rej) =>
-            setTimeout(
-              () => rej(new Error("Fetch timed out")),
-              FETCH_TIMEOUT_MS,
-            ),
-          ),
-        ]);
+        const fetched = await fetchRef(repoPath, branch);
         if (!fetched.ok) {
           results.push({ url: repo.url, behind: 0 });
           continue;

--- a/src/server/extensions/store/repo-ops.ts
+++ b/src/server/extensions/store/repo-ops.ts
@@ -1,7 +1,8 @@
-import { readFile, rm } from "fs/promises";
+import { readFile, rm, readdir } from "fs/promises";
 import { join } from "path";
 import type { RepoInfo, RepoPackageJson } from "../../types";
 import { logger } from "../../utils/logger";
+import { runStoreExclusive } from "./store-lock";
 import {
   normalizeRepoUrl,
   getStoreDir,
@@ -18,6 +19,27 @@ const OLD_OFFICIAL_REPO_URL =
   "https://github.com/fccview/fccview-degoog-extensions.git";
 const DEGOOG_BETA_STORE = process.env.DEGOOG_BETA_STORE === "1";
 const BETA_BRANCH = "develop";
+
+const _isLockError = (stderr: string): boolean =>
+  /shallow\.lock|shallow file has changed|index\.lock|another git process/i.test(
+    stderr,
+  );
+
+const _cleanGitLocks = async (repoPath: string): Promise<void> => {
+  const gitDir = join(repoPath, ".git");
+  try {
+    const entries = await readdir(gitDir);
+    await Promise.all(
+      entries
+        .filter((e) => e.endsWith(".lock"))
+        .map((e) =>
+          rm(join(gitDir, e), { force: true }).catch(() => {}),
+        ),
+    );
+  } catch (err) {
+    logger.debug("store:repo", `could not clean git locks in ${repoPath}`, err);
+  }
+};
 
 const probeBranch = async (url: string, branch: string): Promise<boolean> => {
   const proc = Bun.spawn(["git", "ls-remote", "--heads", url, branch], {
@@ -64,10 +86,10 @@ const headBranch = async (repoPath: string): Promise<string> => {
   return (await new Response(proc.stdout).text()).trim();
 };
 
-const fetchRef = async (
+const _runFetchRef = async (
   repoPath: string,
   branch: string,
-): Promise<{ ok: boolean; notFound: boolean; error: string }> => {
+): Promise<{ exit: number; stderr: string }> => {
   const proc = Bun.spawn(
     [
       "git",
@@ -82,8 +104,24 @@ const fetchRef = async (
     { stdout: "ignore", stderr: "pipe" },
   );
   const exit = await proc.exited;
+  const stderr = exit === 0 ? "" : await new Response(proc.stderr).text();
+  return { exit, stderr };
+};
+
+const fetchRef = async (
+  repoPath: string,
+  branch: string,
+): Promise<{ ok: boolean; notFound: boolean; error: string }> => {
+  let { exit, stderr } = await _runFetchRef(repoPath, branch);
+  if (exit !== 0 && _isLockError(stderr)) {
+    logger.warn(
+      "store:repo",
+      `git lock detected during fetch, clearing stale locks and retrying`,
+    );
+    await _cleanGitLocks(repoPath);
+    ({ exit, stderr } = await _runFetchRef(repoPath, branch));
+  }
   if (exit === 0) return { ok: true, notFound: false, error: "" };
-  const stderr = await new Response(proc.stderr).text();
   const notFound =
     /couldn't find remote ref|remote ref does not exist|invalid refspec/i.test(
       stderr,
@@ -153,6 +191,13 @@ const syncBranch = async (repoPath: string): Promise<void> => {
   }
 };
 
+const resolveTrackedBranch = async (repoPath: string): Promise<string> => {
+  const useBeta =
+    DEGOOG_BETA_STORE &&
+    (await branchExists(repoPath, `origin/${BETA_BRANCH}`));
+  return useBeta ? BETA_BRANCH : await headBranch(repoPath);
+};
+
 function _sanitizeGitError(raw: string): string {
   if (!raw) return raw;
   const storeDir = getStoreDir();
@@ -200,7 +245,11 @@ export function isValidGitUrl(url: string): boolean {
   }
 }
 
-export async function addRepo(url: string): Promise<RepoInfo> {
+export function addRepo(url: string): Promise<RepoInfo> {
+  return runStoreExclusive(() => _addRepo(url));
+}
+
+export async function _addRepo(url: string): Promise<RepoInfo> {
   if (!isValidGitUrl(url)) {
     throw new Error(
       "Invalid git URL. Use http(s) or ssh URL ending in .git or without.",
@@ -272,7 +321,11 @@ export async function addRepo(url: string): Promise<RepoInfo> {
   return repoInfo;
 }
 
-export async function removeRepo(url: string): Promise<void> {
+export function removeRepo(url: string): Promise<void> {
+  return runStoreExclusive(() => _removeRepo(url));
+}
+
+async function _removeRepo(url: string): Promise<void> {
   const data = await readReposData();
   const repo = getRepoByUrl(data, url);
   if (!repo) throw new Error("Repository not found.");
@@ -296,60 +349,75 @@ export async function removeRepo(url: string): Promise<void> {
   await writeReposData(data);
 }
 
-export async function refreshRepo(url?: string): Promise<void> {
-  const data = await readReposData();
-  const repos = url ? [getRepoByUrl(data, url)] : data.repos;
-  const toRefresh = repos.filter((r): r is RepoInfo => r != null);
-  for (const repo of toRefresh) {
-    const repoPath = join(getStoreDir(), repo.localPath);
-    try {
-      await syncBranch(repoPath);
-      const useBeta =
-        DEGOOG_BETA_STORE &&
-        (await branchExists(repoPath, `origin/${BETA_BRANCH}`));
-      const branch = useBeta ? BETA_BRANCH : await headBranch(repoPath);
-      const fetched = await fetchRef(repoPath, branch);
-      if (!fetched.ok) {
-        repo.error = fetched.error || `Git fetch failed for ${branch}`;
-        continue;
-      }
-      const reset = await hardReset(repoPath, `origin/${branch}`);
-      if (!reset.ok) {
-        repo.error = reset.error || `Git reset failed for ${branch}`;
-        continue;
-      }
-      repo.error = null;
-      repo.lastFetched = new Date().toISOString();
-      const pkgPath = join(repoPath, "package.json");
-      const raw = await readFile(pkgPath, "utf-8");
-      const pkg = JSON.parse(raw) as RepoPackageJson;
-      repo.name = pkg.name ?? repo.name;
-      repo.description = pkg.description ?? repo.description;
-      repo.repoImage = pkg["repo-image"] ?? null;
-    } catch (e) {
-      repo.error = e instanceof Error ? e.message : String(e);
+async function _refreshRepo(repo: RepoInfo): Promise<void> {
+  const repoPath = join(getStoreDir(), repo.localPath);
+  try {
+    await syncBranch(repoPath);
+    const branch = await resolveTrackedBranch(repoPath);
+    const fetched = await fetchRef(repoPath, branch);
+    if (!fetched.ok) {
+      repo.error = fetched.error || `Git fetch failed for ${branch}`;
+      return;
     }
+    const reset = await hardReset(repoPath, `origin/${branch}`);
+    if (!reset.ok) {
+      repo.error = reset.error || `Git reset failed for ${branch}`;
+      return;
+    }
+    repo.error = null;
+    repo.lastFetched = new Date().toISOString();
+    const pkgPath = join(repoPath, "package.json");
+    const raw = await readFile(pkgPath, "utf-8");
+    const pkg = JSON.parse(raw) as RepoPackageJson;
+    repo.name = pkg.name ?? repo.name;
+    repo.description = pkg.description ?? repo.description;
+    repo.repoImage = pkg["repo-image"] ?? null;
+  } catch (e) {
+    repo.error = e instanceof Error ? e.message : String(e);
   }
-  await writeReposData(data);
 }
 
-export async function refreshAllRepos(): Promise<
-  { url: string; error: string | null }[]
-> {
-  const data = await readReposData();
-  const results: { url: string; error: string | null }[] = [];
-  for (const repo of data.repos) {
-    try {
-      await refreshRepo(repo.url);
-      const updated = await readReposData();
-      const r = getRepoByUrl(updated, repo.url);
-      results.push({ url: repo.url, error: r?.error ?? null });
-    } catch (err) {
-      logger.warn("store:repo", `refresh failed for ${repo.url}`, err);
-      results.push({ url: repo.url, error: "Refresh failed" });
+export function refreshRepo(url?: string): Promise<void> {
+  return runStoreExclusive(async () => {
+    const data = await readReposData();
+    const repos = url ? [getRepoByUrl(data, url)] : data.repos;
+    const toRefresh = repos.filter((r): r is RepoInfo => r != null);
+    for (const repo of toRefresh) await _refreshRepo(repo);
+    await writeReposData(data);
+  });
+}
+
+export interface RefreshProgress {
+  url: string;
+  name: string;
+  i: number;
+  total: number;
+  phase: "start" | "ok" | "failed";
+  error?: string;
+}
+
+export function refreshAllRepos(
+  onProgress?: (p: RefreshProgress) => void,
+): Promise<{ url: string; error: string | null }[]> {
+  return runStoreExclusive(async () => {
+    const data = await readReposData();
+    const results: { url: string; error: string | null }[] = [];
+    const total = data.repos.length;
+    for (let idx = 0; idx < total; idx++) {
+      const repo = data.repos[idx];
+      const base = { url: repo.url, name: repo.name, i: idx + 1, total };
+      onProgress?.({ ...base, phase: "start" });
+      await _refreshRepo(repo);
+      results.push({ url: repo.url, error: repo.error });
+      onProgress?.({
+        ...base,
+        phase: repo.error ? "failed" : "ok",
+        ...(repo.error ? { error: repo.error } : {}),
+      });
     }
-  }
-  return results;
+    await writeReposData(data);
+    return results;
+  });
 }
 
 export interface RepoStatus {
@@ -357,22 +425,10 @@ export interface RepoStatus {
   behind: number;
 }
 
-async function getBehindCount(repoPath: string): Promise<number> {
-  let remoteRef = "origin/HEAD";
-  const refs = DEGOOG_BETA_STORE
-    ? [`origin/${BETA_BRANCH}`, "origin/HEAD", "origin/main", "origin/master"]
-    : ["origin/HEAD", "origin/main", "origin/master"];
-  for (const ref of refs) {
-    const proc = Bun.spawn(["git", "-C", repoPath, "rev-parse", ref], {
-      stdout: "ignore",
-      stderr: "ignore",
-    });
-    const exit = await proc.exited;
-    if (exit === 0) {
-      remoteRef = ref;
-      break;
-    }
-  }
+async function getBehindCount(
+  repoPath: string,
+  remoteRef: string,
+): Promise<number> {
   const countProc = Bun.spawn(
     ["git", "-C", repoPath, "rev-list", "--count", `HEAD..${remoteRef}`],
     { stdout: "pipe", stderr: "ignore" },
@@ -384,40 +440,37 @@ async function getBehindCount(repoPath: string): Promise<number> {
   return Number.isNaN(n) ? 0 : Math.max(0, n);
 }
 
-export async function getReposStatus(): Promise<RepoStatus[]> {
-  const data = await readReposData();
-  const storeDir = getStoreDir();
-  const results: RepoStatus[] = [];
-  for (const repo of data.repos) {
-    const repoPath = join(storeDir, repo.localPath);
-    try {
-      const fetchProc = Bun.spawn(["git", "-C", repoPath, "fetch", "origin"], {
-        stdout: "ignore",
-        stderr: "pipe",
-      });
-      await Promise.race([
-        fetchProc.exited,
-        new Promise<number>((_, rej) =>
-          setTimeout(() => {
-            fetchProc.kill();
-            rej(new Error("Fetch timed out"));
-          }, FETCH_TIMEOUT_MS),
-        ),
-      ]);
-    } catch (err) {
-      logger.warn("store:repo", `fetch failed for ${repo.url}`, err);
-      results.push({ url: repo.url, behind: 0 });
-      continue;
+export function getReposStatus(): Promise<RepoStatus[]> {
+  return runStoreExclusive(async () => {
+    const data = await readReposData();
+    const storeDir = getStoreDir();
+    const results: RepoStatus[] = [];
+    for (const repo of data.repos) {
+      const repoPath = join(storeDir, repo.localPath);
+      try {
+        const branch = await resolveTrackedBranch(repoPath);
+        const fetched = await Promise.race([
+          fetchRef(repoPath, branch),
+          new Promise<{ ok: boolean }>((_, rej) =>
+            setTimeout(
+              () => rej(new Error("Fetch timed out")),
+              FETCH_TIMEOUT_MS,
+            ),
+          ),
+        ]);
+        if (!fetched.ok) {
+          results.push({ url: repo.url, behind: 0 });
+          continue;
+        }
+        const behind = await getBehindCount(repoPath, `origin/${branch}`);
+        results.push({ url: repo.url, behind });
+      } catch (err) {
+        logger.warn("store:repo", `status check failed for ${repo.url}`, err);
+        results.push({ url: repo.url, behind: 0 });
+      }
     }
-    try {
-      const behind = await getBehindCount(repoPath);
-      results.push({ url: repo.url, behind });
-    } catch (err) {
-      logger.warn("store:repo", `behind count failed for ${repo.url}`, err);
-      results.push({ url: repo.url, behind: 0 });
-    }
-  }
-  return results;
+    return results;
+  });
 }
 
 async function _migrateOfficialRepo(): Promise<void> {

--- a/src/server/extensions/store/store-lock.ts
+++ b/src/server/extensions/store/store-lock.ts
@@ -1,0 +1,13 @@
+import { createMutex } from "../../utils/mutex";
+
+/**
+ * Single store-wide lock shared by every git and filesystem mutation in the
+ * extension store. Repo clone/fetch/reset and item install/update/uninstall all
+ * queue through here so two git processes never touch the same shallow repo at
+ * once. This is what stops the ".git/shallow.lock" and "shallow file has
+ * changed" failures when operations stack up.
+ *
+ * The mutex is not reentrant: anything already holding it must call only the
+ * unlocked internal helpers, never the public locked wrappers.
+ */
+export const runStoreExclusive = createMutex();

--- a/src/server/routes/store.ts
+++ b/src/server/routes/store.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { existsSync } from "fs";
 import { canBalrogPass, gandalf } from "./settings-auth";
 import { resolve, relative } from "path";
@@ -26,6 +26,15 @@ import { getBaseUrl } from "../utils/base-url";
 import { logger } from "../utils/logger";
 
 const router = new Hono();
+
+/**
+ * Mutating SSE routes are GET (EventSource cannot use other verbs), so they must
+ * not accept the auto-sent settings cookie or they would be CSRF-triggerable by
+ * a cross-site page. Require the token explicitly from a header or query param,
+ * which a cross-site request cannot supply.
+ */
+const explicitToken = (c: Context): string | undefined =>
+  c.req.header("x-settings-token") ?? c.req.query("token");
 
 type SseSend = (event: string, data: unknown) => void;
 
@@ -286,7 +295,7 @@ router.post("/api/store/update-all", async (c) => {
 });
 
 router.get("/api/store/update-all/stream", async (c) => {
-  if (!(await gandalf(canBalrogPass(c))))
+  if (!(await gandalf(explicitToken(c))))
     return c.json({ error: "You shall not pass!" }, 401);
   return streamStoreProgress(c.req.raw.signal, async (send) => {
     const result = await updateAllItems((p) => send("item", p));
@@ -295,7 +304,7 @@ router.get("/api/store/update-all/stream", async (c) => {
 });
 
 router.get("/api/store/repos/refresh/stream", async (c) => {
-  if (!(await gandalf(canBalrogPass(c))))
+  if (!(await gandalf(explicitToken(c))))
     return c.json({ error: "You shall not pass!" }, 401);
   return streamStoreProgress(c.req.raw.signal, async (send) => {
     const results = await refreshAllRepos((p) => send("repo", p));

--- a/src/server/routes/store.ts
+++ b/src/server/routes/store.ts
@@ -23,8 +23,50 @@ import {
 } from "../extensions/store";
 import { ExtensionStoreType } from "../types";
 import { getBaseUrl } from "../utils/base-url";
+import { logger } from "../utils/logger";
 
 const router = new Hono();
+
+type SseSend = (event: string, data: unknown) => void;
+
+function streamStoreProgress(
+  signal: AbortSignal,
+  run: (send: SseSend) => Promise<void>,
+): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    async start(controller) {
+      let closed = false;
+      const send: SseSend = (event, data) => {
+        if (closed || signal.aborted) return;
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+          );
+        } catch (err) {
+          logger.debug("store:stream", "client disconnected", err);
+          closed = true;
+        }
+      };
+      try {
+        await run(send);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Operation failed";
+        logger.warn("store:stream", `store progress stream failed: ${message}`);
+        send("failed", { error: message });
+      } finally {
+        if (!closed) controller.close();
+      }
+    },
+  });
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
 
 const VALID_TYPES: ExtensionStoreType[] = Object.values(ExtensionStoreType);
 
@@ -241,6 +283,25 @@ router.post("/api/store/update-all", async (c) => {
     const message = e instanceof Error ? e.message : "Update failed";
     return c.json({ error: message }, 400);
   }
+});
+
+router.get("/api/store/update-all/stream", async (c) => {
+  if (!(await gandalf(canBalrogPass(c))))
+    return c.json({ error: "You shall not pass!" }, 401);
+  return streamStoreProgress(c.req.raw.signal, async (send) => {
+    const result = await updateAllItems((p) => send("item", p));
+    send("done", result);
+  });
+});
+
+router.get("/api/store/repos/refresh/stream", async (c) => {
+  if (!(await gandalf(canBalrogPass(c))))
+    return c.json({ error: "You shall not pass!" }, 401);
+  return streamStoreProgress(c.req.raw.signal, async (send) => {
+    const results = await refreshAllRepos((p) => send("repo", p));
+    const failed = results.filter((r) => r.error).length;
+    send("done", { refreshed: results.length - failed, failed });
+  });
 });
 
 router.delete("/api/store/untracked", async (c) => {

--- a/src/server/routes/store.ts
+++ b/src/server/routes/store.ts
@@ -1,4 +1,4 @@
-import { Hono, type Context } from "hono";
+import { Hono } from "hono";
 import { existsSync } from "fs";
 import { canBalrogPass, gandalf } from "./settings-auth";
 import { resolve, relative } from "path";
@@ -26,15 +26,6 @@ import { getBaseUrl } from "../utils/base-url";
 import { logger } from "../utils/logger";
 
 const router = new Hono();
-
-/**
- * Mutating SSE routes are GET (EventSource cannot use other verbs), so they must
- * not accept the auto-sent settings cookie or they would be CSRF-triggerable by
- * a cross-site page. Require the token explicitly from a header or query param,
- * which a cross-site request cannot supply.
- */
-const explicitToken = (c: Context): string | undefined =>
-  c.req.header("x-settings-token") ?? c.req.query("token");
 
 type SseSend = (event: string, data: unknown) => void;
 
@@ -295,7 +286,7 @@ router.post("/api/store/update-all", async (c) => {
 });
 
 router.get("/api/store/update-all/stream", async (c) => {
-  if (!(await gandalf(explicitToken(c))))
+  if (!(await gandalf(canBalrogPass(c))))
     return c.json({ error: "You shall not pass!" }, 401);
   return streamStoreProgress(c.req.raw.signal, async (send) => {
     const result = await updateAllItems((p) => send("item", p));
@@ -304,7 +295,7 @@ router.get("/api/store/update-all/stream", async (c) => {
 });
 
 router.get("/api/store/repos/refresh/stream", async (c) => {
-  if (!(await gandalf(explicitToken(c))))
+  if (!(await gandalf(canBalrogPass(c))))
     return c.json({ error: "You shall not pass!" }, 401);
   return streamStoreProgress(c.req.raw.signal, async (send) => {
     const results = await refreshAllRepos((p) => send("repo", p));

--- a/src/styles/components/overrides/_store.scss
+++ b/src/styles/components/overrides/_store.scss
@@ -623,6 +623,7 @@
   padding: $space-3;
   border-radius: inherit;
   background: var(--bg-light);
+  pointer-events: none;
 }
 
 .store-progress-label {

--- a/src/styles/components/overrides/_store.scss
+++ b/src/styles/components/overrides/_store.scss
@@ -606,3 +606,94 @@
   padding: $space-2 $space-4;
   letter-spacing: 0.02em;
 }
+
+.store-progress-host {
+  position: relative;
+}
+
+.store-progress {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $space-2;
+  padding: $space-3;
+  border-radius: inherit;
+  background: var(--bg-light);
+}
+
+.store-progress-label {
+  font-size: $font-size-small;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.store-progress-bar {
+  width: 80%;
+  max-width: 12rem;
+  height: $space-2;
+  border-radius: $radius-pill;
+  background: var(--bg-hover);
+  overflow: hidden;
+}
+
+.store-progress-bar-fill {
+  display: block;
+  width: 40%;
+  height: 100%;
+  border-radius: $radius-pill;
+  background: $primary;
+}
+
+.is-working .store-progress-bar-fill {
+  animation: store-progress-slide 1s ease-in-out infinite;
+}
+
+.is-ok {
+  .store-progress-label {
+    color: $primary;
+  }
+
+  .store-progress-bar-fill {
+    width: 100%;
+    background: $primary;
+  }
+}
+
+.is-failed {
+  .store-progress-label {
+    color: $danger;
+  }
+
+  .store-progress-bar-fill {
+    width: 100%;
+    background: $danger;
+  }
+}
+
+.store-repo-item {
+  .store-progress {
+    padding: $space-1;
+    gap: 0;
+  }
+
+  .store-progress-label {
+    display: none;
+  }
+
+  .store-progress-bar {
+    width: 90%;
+  }
+}
+
+@keyframes store-progress-slide {
+  0% {
+    transform: translateX(-110%);
+  }
+  100% {
+    transform: translateX(275%);
+  }
+}

--- a/tests/store/store-progress.test.ts
+++ b/tests/store/store-progress.test.ts
@@ -92,7 +92,10 @@ describe("store progress streaming auth (CSRF)", () => {
   let storeRouter: {
     request: (req: Request | string) => Response | Promise<Response>;
   };
-  let tokenStore: { set: (t: string, exp: number) => void };
+  let tokenStore: {
+    set: (t: string, exp: number) => void;
+    delete: (t: string) => void;
+  };
   let validToken: string;
   let tmp: string;
   let savedDataDir: string | undefined;
@@ -112,6 +115,7 @@ describe("store progress streaming auth (CSRF)", () => {
   });
 
   afterAll(async () => {
+    if (validToken) tokenStore.delete(validToken);
     if (savedDataDir === undefined) delete process.env.DEGOOG_DATA_DIR;
     else process.env.DEGOOG_DATA_DIR = savedDataDir;
     if (savedPasswords === undefined) delete process.env.DEGOOG_SETTINGS_PASSWORDS;

--- a/tests/store/store-progress.test.ts
+++ b/tests/store/store-progress.test.ts
@@ -119,13 +119,15 @@ describe("store progress streaming auth (CSRF)", () => {
     await rm(tmp, { recursive: true, force: true });
   });
 
-  test("rejects a cookie-only request (no header/query token)", async () => {
+  test("accepts the settings cookie like the non-stream store routes", async () => {
     const res = await storeRouter.request(
       new Request("http://localhost/api/store/update-all/stream", {
         headers: { cookie: `settings-token=${validToken}` },
       }),
     );
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: done");
   });
 
   test("accepts an explicit query token", async () => {

--- a/tests/store/store-progress.test.ts
+++ b/tests/store/store-progress.test.ts
@@ -77,4 +77,63 @@ describe("store progress streaming", () => {
     expect(results).toEqual([]);
     expect(seen).toHaveLength(0);
   });
+
+  test("refreshRepo throws when the requested repository is missing", async () => {
+    const { refreshRepo } = await import(
+      "../../src/server/extensions/store/repo-ops"
+    );
+    await expect(
+      refreshRepo("https://github.com/nope/missing.git"),
+    ).rejects.toThrow("Repository not found.");
+  });
+});
+
+describe("store progress streaming auth (CSRF)", () => {
+  let storeRouter: {
+    request: (req: Request | string) => Response | Promise<Response>;
+  };
+  let tokenStore: { set: (t: string, exp: number) => void };
+  let validToken: string;
+  let tmp: string;
+  let savedDataDir: string | undefined;
+  let savedPasswords: string | undefined;
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "degoog-store-csrf-"));
+    savedDataDir = process.env.DEGOOG_DATA_DIR;
+    savedPasswords = process.env.DEGOOG_SETTINGS_PASSWORDS;
+    process.env.DEGOOG_DATA_DIR = tmp;
+    process.env.DEGOOG_SETTINGS_PASSWORDS = "testpw";
+    storeRouter = (await import("../../src/server/routes/store")).default;
+    const tokens = await import("../../src/server/utils/settings-tokens");
+    tokenStore = tokens.tokenStore;
+    validToken = tokens.generateSettingsToken();
+    tokenStore.set(validToken, Date.now() + tokens.TOKEN_TTL_MS);
+  });
+
+  afterAll(async () => {
+    if (savedDataDir === undefined) delete process.env.DEGOOG_DATA_DIR;
+    else process.env.DEGOOG_DATA_DIR = savedDataDir;
+    if (savedPasswords === undefined) delete process.env.DEGOOG_SETTINGS_PASSWORDS;
+    else process.env.DEGOOG_SETTINGS_PASSWORDS = savedPasswords;
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("rejects a cookie-only request (no header/query token)", async () => {
+    const res = await storeRouter.request(
+      new Request("http://localhost/api/store/update-all/stream", {
+        headers: { cookie: `settings-token=${validToken}` },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("accepts an explicit query token", async () => {
+    const res = await storeRouter.request(
+      `http://localhost/api/store/update-all/stream?token=${validToken}`,
+    );
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain("event: done");
+  });
 });

--- a/tests/store/store-progress.test.ts
+++ b/tests/store/store-progress.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runStoreExclusive } from "../../src/server/extensions/store/store-lock";
+
+describe("store-lock serialization", () => {
+  test("runStoreExclusive runs store operations one at a time", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const op = () =>
+      runStoreExclusive(async () => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 10));
+        active--;
+      });
+    await Promise.all([op(), op(), op(), op()]);
+    expect(maxActive).toBe(1);
+    expect(active).toBe(0);
+  });
+});
+
+describe("store progress streaming", () => {
+  let storeRouter: {
+    request: (req: Request | string) => Response | Promise<Response>;
+  };
+  let tmp: string;
+  let savedDataDir: string | undefined;
+  let savedDanger: string | undefined;
+
+  beforeAll(async () => {
+    tmp = await mkdtemp(join(tmpdir(), "degoog-store-"));
+    savedDataDir = process.env.DEGOOG_DATA_DIR;
+    savedDanger = process.env.DEGOOG_DANGEROUSLY_NO_PASSWORD;
+    process.env.DEGOOG_DATA_DIR = tmp;
+    process.env.DEGOOG_DANGEROUSLY_NO_PASSWORD = "true";
+    storeRouter = (await import("../../src/server/routes/store")).default;
+  });
+
+  afterAll(async () => {
+    if (savedDataDir === undefined) delete process.env.DEGOOG_DATA_DIR;
+    else process.env.DEGOOG_DATA_DIR = savedDataDir;
+    if (savedDanger === undefined) delete process.env.DEGOOG_DANGEROUSLY_NO_PASSWORD;
+    else process.env.DEGOOG_DANGEROUSLY_NO_PASSWORD = savedDanger;
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  test("update-all stream emits an SSE done event", async () => {
+    const res = await storeRouter.request(
+      "http://localhost/api/store/update-all/stream",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("event: done");
+    expect(text).toContain('"updated":0');
+  });
+
+  test("repos refresh stream emits an SSE done event", async () => {
+    const res = await storeRouter.request(
+      "http://localhost/api/store/repos/refresh/stream",
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/event-stream");
+    const text = await res.text();
+    expect(text).toContain("event: done");
+    expect(text).toContain('"refreshed":0');
+  });
+
+  test("refreshAllRepos reports no progress when there are no repos", async () => {
+    const { refreshAllRepos } = await import(
+      "../../src/server/extensions/store/repo-ops"
+    );
+    const seen: unknown[] = [];
+    const results = await refreshAllRepos((p) => seen.push(p));
+    expect(results).toEqual([]);
+    expect(seen).toHaveLength(0);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store actions (install/update/refresh) now show live per-item and per-repository progress in a dedicated overlay.
  * Bulk update and bulk refresh now stream real-time progress via server-sent events.
* **Bug Fixes**
  * Improved failure handling: network/operation errors now reliably set clear failed states instead of alert-based interruptions.
  * Store operations are more reliable under concurrent use, with improved refresh/status behavior and handling of stale git locks.
* **Tests**
  * Added automated coverage for streaming endpoints, progress handling, and concurrency locking.
* **Style**
  * Added animated progress visuals for working, success, and failure states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->