### PR TITLE
Added option to filter which category uses streaming results

### DIFF
--- a/src/client/settings/server/render.ts
+++ b/src/client/settings/server/render.ts
@@ -123,6 +123,7 @@ const _renderStreamingSection = (): string => `
       ${_toggle("settings-streaming-enabled", "settings-page.server.streaming-enable", { aria: "settings-page.server.streaming-enable-aria", title: "settings-page.server.streaming-enable-tooltip" })}
       <div class="settings-streaming-options" id="settings-streaming-options" style="display: none">
         <fieldset class="settings-fieldset settings-fieldset--compact">
+          <div id="settings-streaming-type-checks" class="settings-streaming-type-checks"></div>
           ${_toggle("settings-streaming-auto-retry", "settings-page.server.streaming-auto-retry", { aria: "settings-page.server.streaming-auto-retry-aria" })}
           <div class="settings-streaming-retry-wrap settings-fieldset settings-fieldset-inverse settings-fieldset--compact" id="settings-streaming-retry-wrap" style="display: none">
             <label for="settings-streaming-max-retries" class="settings-proxy-urls-label">${escapeHtml(t("settings-page.server.streaming-max-retries-label"))}</label>

--- a/src/client/settings/server/tab.ts
+++ b/src/client/settings/server/tab.ts
@@ -1,5 +1,7 @@
 import { copyTextToClipboard } from "../../utils/clipboard";
 import { getBase } from "../../utils/base-url";
+import { escapeHtml } from "../../utils/dom";
+import { getAllSearchTypes } from "../../utils/engines";
 import { authHeaders } from "../../utils/request";
 import { saveBatch, saveField } from "../../utils/settings-api";
 import type {
@@ -50,21 +52,7 @@ async function _initStreamingTypeChecks(
   const container = document.getElementById("settings-streaming-type-checks");
   if (!container) return;
   const disabled = new Set(disabledTypes.split("\n").map((s) => s.trim()).filter(Boolean));
-  let types: string[] = [];
-  try {
-    const res = await fetch(`${getBase()}/api/engines`);
-    if (res.ok) {
-      const data = (await res.json()) as { engines: { searchTypes: string[]; primaryType: string }[] };
-      const seen = new Set<string>();
-      for (const e of data.engines) {
-        for (const t of (e.searchTypes?.length ? e.searchTypes : [e.primaryType ?? "web"])) {
-          seen.add(t);
-        }
-      }
-      types = [...seen];
-    }
-  } catch { /* fall through */ }
-  if (!types.length) types = ["web", "images", "videos", "news", "files"];
+  const types = [...(await getAllSearchTypes())];
 
   if (types.length <= 1) {
     container.remove();

--- a/src/client/settings/server/tab.ts
+++ b/src/client/settings/server/tab.ts
@@ -66,6 +66,11 @@ async function _initStreamingTypeChecks(
   } catch { /* fall through */ }
   if (!types.length) types = ["web", "images", "videos", "news", "files"];
 
+  if (types.length <= 1) {
+    container.remove();
+    return;
+  }
+
   const _save = async (): Promise<void> => {
     const checks = container.querySelectorAll<HTMLInputElement>("input[type=checkbox]");
     const nowDisabled = [...checks].filter((c) => !c.checked).map((c) => c.value).join("\n");

--- a/src/client/settings/server/tab.ts
+++ b/src/client/settings/server/tab.ts
@@ -80,9 +80,9 @@ async function _initStreamingTypeChecks(
 
   container.innerHTML = types.map((type) =>
     `<label class="settings-toggle-wrap degoog-toggle-wrap">
-      <input type="checkbox" class="settings-toggle" value="${type}"${disabled.has(type) ? "" : " checked"} />
+      <input type="checkbox" class="settings-toggle" value="${escapeHtml(type)}"${disabled.has(type) ? "" : " checked"} />
       <span class="toggle-slider degoog-toggle"></span>
-      <span class="settings-toggle-label">${type}</span>
+      <span class="settings-toggle-label">${escapeHtml(type)}</span>
     </label>`,
   ).join("");
 

--- a/src/client/settings/server/tab.ts
+++ b/src/client/settings/server/tab.ts
@@ -1,7 +1,7 @@
 import { copyTextToClipboard } from "../../utils/clipboard";
 import { getBase } from "../../utils/base-url";
 import { authHeaders } from "../../utils/request";
-import { saveBatch } from "../../utils/settings-api";
+import { saveBatch, saveField } from "../../utils/settings-api";
 import type {
   ButtonStateHandler,
   ServerSettingsData,
@@ -42,6 +42,54 @@ const TOGGLE_WRAP_PAIRS = [
   ["domain-replace-enabled", "domain-replace-wrap"],
   ["domain-score-enabled", "domain-score-wrap"],
 ] as const;
+
+async function _initStreamingTypeChecks(
+  disabledTypes: string,
+  getToken: () => string | null,
+): Promise<void> {
+  const container = document.getElementById("settings-streaming-type-checks");
+  if (!container) return;
+  const disabled = new Set(disabledTypes.split("\n").map((s) => s.trim()).filter(Boolean));
+  let types: string[] = [];
+  try {
+    const res = await fetch(`${getBase()}/api/engines`);
+    if (res.ok) {
+      const data = (await res.json()) as { engines: { searchTypes: string[]; primaryType: string }[] };
+      const seen = new Set<string>();
+      for (const e of data.engines) {
+        for (const t of (e.searchTypes?.length ? e.searchTypes : [e.primaryType ?? "web"])) {
+          seen.add(t);
+        }
+      }
+      types = [...seen];
+    }
+  } catch { /* fall through */ }
+  if (!types.length) types = ["web", "images", "videos", "news", "files"];
+
+  const _save = async (): Promise<void> => {
+    const checks = container.querySelectorAll<HTMLInputElement>("input[type=checkbox]");
+    const nowDisabled = [...checks].filter((c) => !c.checked).map((c) => c.value).join("\n");
+    const ok = await saveField("streamingDisabledTypes", nowDisabled, getToken);
+    if (ok) {
+      window.dispatchEvent(new Event("extensions-saved"));
+      flashSuccess(t("settings-page.server.saved"));
+    } else {
+      flashError(t("settings-page.server.save-failed-network"));
+    }
+  };
+
+  container.innerHTML = types.map((type) =>
+    `<label class="settings-toggle-wrap degoog-toggle-wrap">
+      <input type="checkbox" class="settings-toggle" value="${type}"${disabled.has(type) ? "" : " checked"} />
+      <span class="toggle-slider degoog-toggle"></span>
+      <span class="settings-toggle-label">${type}</span>
+    </label>`,
+  ).join("");
+
+  container.querySelectorAll<HTMLInputElement>("input[type=checkbox]").forEach((cb) => {
+    cb.addEventListener("change", () => void _save());
+  });
+}
 
 function _renderApiKey(): void {
   const element = document.getElementById("settings-api-key-value");
@@ -96,6 +144,7 @@ async function _loadServerSettings(
     setToggle("streaming-enabled", data.streamingEnabled);
     setToggle("streaming-auto-retry", data.streamingAutoRetry);
     setVal("streaming-max-retries", data.streamingMaxRetries);
+    void _initStreamingTypeChecks(data.streamingDisabledTypes ?? "", getToken);
 
     setToggle("domain-block-enabled", data.domainBlockEnabled);
     setListVal("domain-block-list", "domainBlockList", data.domainBlockList);

--- a/src/client/types/settings-server.ts
+++ b/src/client/types/settings-server.ts
@@ -21,6 +21,7 @@ export type ServerSettingsData = {
   streamingEnabled?: BoolSetting;
   streamingAutoRetry?: BoolSetting;
   streamingMaxRetries?: string;
+  streamingDisabledTypes?: string;
   domainBlockEnabled?: BoolSetting;
   domainBlockList?: string;
   domainBlockUiEnabled?: BoolSetting;

--- a/src/client/utils/engines.ts
+++ b/src/client/utils/engines.ts
@@ -46,6 +46,21 @@ const _typesForEngine = (engine: {
   return ["web"];
 };
 
+export const getAllSearchTypes = async (): Promise<Set<string>> => {
+  const types = new Set<string>();
+  try {
+    const reg = await getRegistry();
+    for (const engine of reg.engines) {
+      for (const t of _typesForEngine(engine)) {
+        types.add(t);
+      }
+    }
+  } catch (err) {
+    console.warn("[engines] could not load registry for search types", err);
+  }
+  return types;
+};
+
 export const getEnabledSearchTypes = async (): Promise<Set<string>> => {
   const engines = await getEngines();
   const reg = await getRegistry();

--- a/src/client/utils/search/search-actions-perform.ts
+++ b/src/client/utils/search/search-actions-perform.ts
@@ -108,11 +108,13 @@ export async function performSearch(
     ? getNaturalLanguageBangQuery(query, commands)
     : null;
 
+  const streamingConfig = await fetchStreamingConfig();
   if (
     !naturalBangQuery &&
     !state.postMethodEnabled &&
     (!page || page === 1) &&
-    (await fetchStreamingConfig())
+    streamingConfig.enabled &&
+    !streamingConfig.disabledTypes.includes(resolvedType)
   ) {
     abortStreamingSearch();
     return performStreamingSearch(

--- a/src/client/utils/streaming-config.ts
+++ b/src/client/utils/streaming-config.ts
@@ -1,6 +1,6 @@
 import { getBase } from "./base-url";
 
-let _config: { enabled: boolean } | null = null;
+let _config: { enabled: boolean; disabledTypes: string[] } | null = null;
 
 if (typeof window !== "undefined") {
   window.addEventListener("extensions-saved", () => {
@@ -8,16 +8,17 @@ if (typeof window !== "undefined") {
   });
 }
 
-export const fetchStreamingConfig = async (): Promise<boolean> => {
-  if (_config) return _config.enabled;
+export const fetchStreamingConfig = async (): Promise<{ enabled: boolean; disabledTypes: string[] }> => {
+  if (_config) return _config;
   try {
     const res = await fetch(`${getBase()}/api/settings/streaming`);
     if (res.ok) {
-      _config = (await res.json()) as { enabled: boolean };
-      return _config.enabled;
+      const data = (await res.json()) as { enabled: boolean; disabledTypes?: string[] };
+      _config = { enabled: data.enabled, disabledTypes: data.disabledTypes ?? [] };
+      return _config;
     }
   } catch (err) {
     console.debug("[streaming] config fetch failed", err);
   }
-  return false;
+  return { enabled: false, disabledTypes: [] };
 };

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -186,6 +186,7 @@ router.get("/api/settings/streaming", async (c) => {
     enabled: asBoolean(settings.streamingEnabled),
     autoRetry: asBoolean(settings.streamingAutoRetry),
     maxRetries: parseInt(asString(settings.streamingMaxRetries) || "2", 10),
+    disabledTypes: asString(settings.streamingDisabledTypes ?? "").split("\n").map(s => s.trim()).filter(Boolean),
   });
 });
 

--- a/src/server/utils/settings-schema.ts
+++ b/src/server/utils/settings-schema.ts
@@ -26,6 +26,7 @@ export const SETTINGS_SCHEMA = {
   streamingEnabled:             { kind: "boolean", default: true },
   streamingAutoRetry:           { kind: "boolean", default: true },
   streamingMaxRetries:          { kind: "number",  default: "2" },
+  streamingDisabledTypes:       { kind: "lines",   default: "" },
   postMethodEnabled:            { kind: "boolean", default: false },
   defaultTheme:                 { kind: "string",  default: "system" },
   domainBlockEnabled:           { kind: "boolean", default: false },

--- a/src/styles/components/overrides/_settings.scss
+++ b/src/styles/components/overrides/_settings.scss
@@ -495,6 +495,21 @@
   margin: 0;
 }
 
+.settings-streaming-type-checks {
+  display: flex;
+  flex-direction: column;
+  gap: $space-1;
+  background: var(--bg);
+  border-radius: $radius-md;
+  padding: $space-2;
+
+  .degoog-toggle-wrap {
+    background: transparent;
+    border-radius: 0;
+    padding: $space-2 $space-3;
+  }
+}
+
 .settings-rl-grid {
   display: grid;
   grid-template-columns: 1fr auto;
@@ -506,6 +521,7 @@
     min-width: 0;
   }
 }
+
 
 .settings-rate-limit-input {
   display: block;


### PR DESCRIPTION
This pull request introduces a new feature allowing users to selectively disable streaming search for specific search types from the server settings UI. It adds a dynamic checkbox list for search types, persists user choices, and ensures the streaming search logic respects these settings. Additional backend and styling changes support this functionality.

**Streaming search type disable feature:**

* Added a new UI section (`settings-streaming-type-checks`) in the server settings to let users enable or disable streaming for specific search types via dynamically generated checkboxes. (`src/client/settings/server/render.ts`, `src/client/settings/server/tab.ts`, `src/styles/components/overrides/_settings.scss`) [[1]](diffhunk://#diff-1ef74f4ef9f119983a9d622b63cc985bae8a5169ac3c774f157c5e417fc5a3f7R126) [[2]](diffhunk://#diff-fb410b3c6ee6e7aab827f0742a3ff89a3126674682097bdacc7d1245b14c9eb4R46-R93) [[3]](diffhunk://#diff-946253154d3bcac97853620640ef81e542025bfbc383fedcd5c873f5650f2b32R498-R512)
* Persisted the disabled search types in the server settings under the new field `streamingDisabledTypes`, and updated the backend schema and API to support this. (`src/client/types/settings-server.ts`, `src/server/utils/settings-schema.ts`, `src/server/routes/settings.ts`) [[1]](diffhunk://#diff-b4f6cc6dda05a91f8ae4b4ec138b7da834b18eef4d1643f6d81d1a7a1213093eR24) [[2]](diffhunk://#diff-a22fd52a4290b76e9809b170cc875aad59ebb916593017b38fbf899d9034a438R29) [[3]](diffhunk://#diff-9c80a1e7dd8967c1bd98b87b50c97f8aedf702f3097dd1efeeecd53a428d57adR189)

**Streaming search logic improvements:**

* Modified the streaming search logic to check the current type against the disabled types before initiating a streaming search. (`src/client/utils/search/search-actions-perform.ts`, `src/client/utils/streaming-config.ts`) [[1]](diffhunk://#diff-7754b71861a05e7dcbdd4eb4cb1f5bd53bae21053c483b695e783eefb6cc6893R111-R117) [[2]](diffhunk://#diff-391e1b25368c198ab19e43350f103d500d53f7e2975e50688da729aa8a6d9a71L3-R23)

**Styling updates:**

* Added and styled the `.settings-streaming-type-checks` class for the new UI section. (`src/styles/components/overrides/_settings.scss`) [[1]](diffhunk://#diff-946253154d3bcac97853620640ef81e542025bfbc383fedcd5c873f5650f2b32R498-R512) [[2]](diffhunk://#diff-946253154d3bcac97853620640ef81e542025bfbc383fedcd5c873f5650f2b32R525)

![image](https://github.com/user-attachments/assets/56d42bf7-24f9-4758-98e6-c879409c8e24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “streaming type checks” checkboxes to Settings to enable/disable specific streaming search types (shown when applicable).
  * Streaming configuration now includes persisted disabled-type selections and restores them on load.

* **Bug Fixes**
  * Streaming start/stop behavior now consistently honors the saved disabled type restrictions.
  * Streaming settings fetching now caches the full streaming configuration (enabled + disabled types) for more reliable decisions.

* **Style**
  * Updated Settings styling with a dedicated layout for the new streaming type checks section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->