### PR TITLE
Added a feature that allows plugins to be rearranged via input.

### DIFF
--- a/src/client/settings/plugins/tab.ts
+++ b/src/client/settings/plugins/tab.ts
@@ -99,7 +99,11 @@ const _glowPos = (card: HTMLElement): void => {
   pos.classList.remove("degoog-card-order-pos--glow");
   void pos.offsetWidth;
   pos.classList.add("degoog-card-order-pos--glow");
-  pos.addEventListener("animationend", () => pos.classList.remove("degoog-card-order-pos--glow"), { once: true });
+  pos.addEventListener("animationend", () => {
+    pos.classList.remove("degoog-card-order-pos--glow");
+    // fccview is onto you!
+    _lastMovedId = null;
+  }, { once: true });
 };
 
 const _refreshOrderBtns = (group: HTMLElement): void => {
@@ -244,7 +248,6 @@ const _renderCards = (
   if (_lastMovedId) {
     const movedCard = cardsEl.querySelector<HTMLElement>(`.ext-card[data-id="${CSS.escape(_lastMovedId)}"]`);
     if (movedCard) _glowPos(movedCard);
-    _lastMovedId = null;
   }
 };
 

--- a/src/client/settings/plugins/tab.ts
+++ b/src/client/settings/plugins/tab.ts
@@ -101,7 +101,6 @@ const _glowPos = (card: HTMLElement): void => {
   pos.classList.add("degoog-card-order-pos--glow");
   pos.addEventListener("animationend", () => {
     pos.classList.remove("degoog-card-order-pos--glow");
-    // fccview is onto you!
     _lastMovedId = null;
   }, { once: true });
 };

--- a/src/client/settings/plugins/tab.ts
+++ b/src/client/settings/plugins/tab.ts
@@ -63,6 +63,7 @@ const _renderPluginCard = (
   const orderBtns = orderable
     ? `<div class="degoog-card-order">
         <button class="degoog-icon-btn degoog-card-order-btn" data-id="${escapeHtml(plugin.id)}" data-dir="up" title="Move up" type="button"><i class="fa-solid fa-chevron-up"></i></button>
+        <input type="number" class="degoog-card-order-pos" min="1" title="Position">
         <button class="degoog-icon-btn degoog-card-order-btn" data-id="${escapeHtml(plugin.id)}" data-dir="down" title="Move down" type="button"><i class="fa-solid fa-chevron-down"></i></button>
       </div>`
     : "";
@@ -89,13 +90,30 @@ const _renderPluginCard = (
     </div>`;
 };
 
+let _lastMovedId: string | null = null;
+
+const _glowPos = (card: HTMLElement): void => {
+  _lastMovedId = card.dataset.id ?? null;
+  const pos = card.querySelector<HTMLInputElement>(".degoog-card-order-pos");
+  if (!pos) return;
+  pos.classList.remove("degoog-card-order-pos--glow");
+  void pos.offsetWidth;
+  pos.classList.add("degoog-card-order-pos--glow");
+  pos.addEventListener("animationend", () => pos.classList.remove("degoog-card-order-pos--glow"), { once: true });
+};
+
 const _refreshOrderBtns = (group: HTMLElement): void => {
   const cards = group.querySelectorAll<HTMLElement>(".ext-card");
   cards.forEach((card, i) => {
     const up = card.querySelector<HTMLButtonElement>('[data-dir="up"]');
     const down = card.querySelector<HTMLButtonElement>('[data-dir="down"]');
+    const pos = card.querySelector<HTMLInputElement>(".degoog-card-order-pos");
     if (up) up.disabled = i === 0;
     if (down) down.disabled = i === cards.length - 1;
+    if (pos) {
+      pos.value = String(i + 1);
+      pos.max = String(cards.length);
+    }
   });
 };
 
@@ -186,6 +204,30 @@ const _bindCards = (
           if (next) cardsEl.insertBefore(next, card);
         }
         _refreshOrderBtns(cardsEl);
+        _glowPos(card);
+        void _savePriorities(cardsEl);
+      });
+    });
+
+  container
+    .querySelectorAll<HTMLInputElement>(".degoog-card-order-pos")
+    .forEach((input) => {
+      input.addEventListener("change", () => {
+        const card = input.closest<HTMLElement>(".ext-card");
+        const cardsEl = input.closest<HTMLElement>(".ext-cards--orderable");
+        if (!card || !cardsEl) return;
+        const cards = Array.from(cardsEl.querySelectorAll<HTMLElement>(".ext-card"));
+        const target = Math.max(1, Math.min(cards.length, parseInt(input.value, 10) || 1)) - 1;
+        const current = cards.indexOf(card);
+        if (target === current) return;
+        if (target >= cards.length - 1) {
+          cardsEl.appendChild(card);
+        } else {
+          const ref = cards[target > current ? target + 1 : target];
+          cardsEl.insertBefore(card, ref);
+        }
+        _refreshOrderBtns(cardsEl);
+        _glowPos(card);
         void _savePriorities(cardsEl);
       });
     });
@@ -199,6 +241,11 @@ const _renderCards = (
   for (const plugin of plugins) html += _renderPluginCard(plugin, true);
   cardsEl.innerHTML = html;
   _refreshOrderBtns(cardsEl);
+  if (_lastMovedId) {
+    const movedCard = cardsEl.querySelector<HTMLElement>(`.ext-card[data-id="${CSS.escape(_lastMovedId)}"]`);
+    if (movedCard) _glowPos(movedCard);
+    _lastMovedId = null;
+  }
 };
 
 let _pluginSearchQuery = "";

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -108,8 +108,18 @@
   }
 }
 
+@keyframes degoog-pos-glow {
+  0%   { color: var(--text-secondary); }
+  30%  { color: var(--primary); }
+  100% { color: var(--text-secondary); }
+}
+
 .degoog-card-order {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   flex-shrink: 0;
+  gap: 0;
 
   &-btn {
     display: block;
@@ -121,10 +131,30 @@
     }
   }
 
-  @media (max-width: 768px) {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
+  &-pos {
+    width: 2rem;
+    text-align: center;
+    padding: 0;
+    font-size: $font-size-small;
+    font-weight: 500;
+    color: var(--text-secondary);
+    border: none;
+    background: transparent;
+    appearance: textfield;
+    line-height: 1.4;
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      display: none;
+    }
+
+    &:focus {
+      outline: none;
+    }
+
+    &--glow {
+      animation: degoog-pos-glow 0.8s ease-out forwards;
+    }
   }
 }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/501dd159-1654-4763-98b3-17911945db3b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a numeric position field for ordering plugin cards, enabling precise placement.
  * Enhanced the reorder UI with glow feedback on the moved card’s position control, including after list refreshes.
* **Bug Fixes**
  * Kept each card’s position input synchronized with its current position (1-based) and the list size.
  * Ensured ordering updates are applied correctly when using up/down controls or directly setting a position, with valid clamping and preserved ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->