### PR TITLE
Icon change

### DIFF
--- a/src/client/settings/store/tab.ts
+++ b/src/client/settings/store/tab.ts
@@ -262,7 +262,7 @@ export async function initStoreTab(
                   <span class="store-updates-row-name">${escapeHtml(i.name)}</span>
                   <span class="store-updates-row-meta">${escapeHtml(i.repoName)} · <span class="store-card-version-old">v${escapeHtml(i.installedVersion || "?")}</span> → v${escapeHtml(i.version)}</span>
                 </div>
-                <button class="btn btn--primary degoog-btn degoog-btn--primary store-btn-update" type="button" data-repo-url="${escapeHtml(i.repoUrl)}" data-item-path="${escapeHtml(i.path)}" data-type="${escapeHtml(i.type)}" aria-label="Update"><i class="fa-solid fa-arrow-down" aria-hidden="true"></i></button>
+                <button class="btn btn--primary degoog-btn degoog-btn--primary store-btn-update" type="button" data-repo-url="${escapeHtml(i.repoUrl)}" data-item-path="${escapeHtml(i.path)}" data-type="${escapeHtml(i.type)}" aria-label="Update"><i class="fa-solid fa-download"></i></button>
               </div>`,
           )
           .join("");


### PR DESCRIPTION
Due to concerns from one of the users I've decided to change the icon from down arrow to download 

<table>
  <tr>
    <td>
      <img width="102" height="81" alt="image"
        src="https://github.com/user-attachments/assets/dd540a72-aae0-45d0-b435-194a80fdf35b" />
    </td>
    <td style="font-size: 32px; padding: 0 10px; vertical-align: middle;">
      →
    </td>
    <td>
      <img width="109" height="82" alt="image"
        src="https://github.com/user-attachments/assets/efcd86da-a714-4055-b6bd-b91f9627b07e" />
    </td>
  </tr>
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the “updates available” button icon in settings to use a download symbol instead of a down-arrow for a clearer visual cue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->