### PR TITLE
Collapsed engine performence tab by default on mobile

### DIFF
--- a/src/client/modules/renderer/render-media.ts
+++ b/src/client/modules/renderer/render-media.ts
@@ -142,7 +142,7 @@ function _expandFromPanel(grid: HTMLElement): void {
   _scrollSelectedIntoView(grid);
 }
 
-const PANEL_LAYOUT_BREAKPOINT = 768;
+export const PANEL_LAYOUT_BREAKPOINT = 768;
 
 registerImageGridPanelSync((isOpen) => {
   const grid = document.querySelector<HTMLElement>(".image-grid");

--- a/src/client/utils/search/streaming-search-dom.ts
+++ b/src/client/utils/search/streaming-search-dom.ts
@@ -93,7 +93,8 @@ export function updateEngineTimings(
   if (!panel) {
     sidebar.querySelector(".skeleton-sidebar")?.remove();
     panel = document.createElement("div");
-    panel.className="sidebar-panel sidebar-accordion streaming-engine-panel open degoog-panel degoog-panel--accordion degoog-panel--stack-item";
+    const openClass = window.innerWidth >= 768 ? " open" : "";
+    panel.className = `sidebar-panel sidebar-accordion streaming-engine-panel${openClass} degoog-panel degoog-panel--accordion degoog-panel--stack-item`;
     panel.innerHTML = `
       <button class="sidebar-accordion-toggle degoog-accordion-toggle degoog-accordion-toggle--sidebar" type="button">
         <span>${t("search-templates.sidebar.engine-performance")}</span>

--- a/src/client/utils/search/streaming-search-dom.ts
+++ b/src/client/utils/search/streaming-search-dom.ts
@@ -3,6 +3,7 @@ import type { EngineTiming, ScoredResult } from "../../types";
 import { renderTemplate } from "../../utils/template";
 import { buildResultContext } from "../../modules/renderer/render";
 import { engineCountHtml } from "./engine-failure";
+import { PANEL_LAYOUT_BREAKPOINT } from "../../modules/renderer/render-media";
 
 const t = window.scopedT("themes/degoog");
 
@@ -93,7 +94,7 @@ export function updateEngineTimings(
   if (!panel) {
     sidebar.querySelector(".skeleton-sidebar")?.remove();
     panel = document.createElement("div");
-    const openClass = window.innerWidth >= 768 ? " open" : "";
+    const openClass = window.innerWidth >= PANEL_LAYOUT_BREAKPOINT ? " open" : "";
     panel.className = `sidebar-panel sidebar-accordion streaming-engine-panel${openClass} degoog-panel degoog-panel--accordion degoog-panel--stack-item`;
     panel.innerHTML = `
       <button class="sidebar-accordion-toggle degoog-accordion-toggle degoog-accordion-toggle--sidebar" type="button">

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -43,6 +43,9 @@ $results-inline-gutter: clamp(
 );
 $header-height: 2.75rem;
 
+$modal-width: 36rem;
+$settings-modal-width: min(56rem, 92vw);
+
 $transition-fast: 0.2s ease;
 $transition-med: 0.3s ease;
 

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -198,8 +198,7 @@
 
   &-footer {
     @include flex-between;
-    border-top: 1px solid var(--border-light);
-    background: #3c4043;
+    background: var(--modal-footer);
     padding: $space-4 $space-6;
   }
 

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -199,6 +199,7 @@
   &-footer {
     @include flex-between;
     border-top: 1px solid var(--border-light);
+    background: rgba(var(--primary-rgb), 0.06);
     padding: $space-4 $space-6;
   }
 

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -154,10 +154,10 @@
   max-height: 90vh;
   max-width: 92vw;
   overflow: hidden;
-  width: 30rem;
+  width: $modal-width;
 
   &--wide {
-    width: min(60rem, 92vw);
+    width: $settings-modal-width;
   }
 
   &-overlay {
@@ -199,7 +199,7 @@
   &-footer {
     @include flex-between;
     border-top: 1px solid var(--border-light);
-    background: rgba(var(--primary-rgb), 0.06);
+    background: #3c4043;
     padding: $space-4 $space-6;
   }
 

--- a/src/styles/components/overrides/_settings.scss
+++ b/src/styles/components/overrides/_settings.scss
@@ -899,7 +899,7 @@ html:has(.settings-page-body) {
 }
 
 .ext-modal--wide {
-  width: min(56rem, 92vw);
+  width: $settings-modal-width;
 }
 
 .shortcut-editor-modal {

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -26,6 +26,7 @@
   --bg: #f1f1f1;
   --bg-light: #fafafa;
   --bg-hover: #fafafa;
+  --modal-footer: rgb(230 229 229);
   --border: #c8d0da;
   --border-light: #dedede;
   --text-primary: #343536;
@@ -54,6 +55,7 @@
   --bg: #25272e;
   --bg-light: #303134;
   --bg-hover: #3c4043;
+  --modal-footer: rgb(60 64 67);
   --border: #5f6368;
   --border-light: #303134;
   --text-primary: #dddddd;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made the streaming search panel’s default open/collapsed state responsive to the layout breakpoint (collapsed on smaller screens, expanded on larger screens).
* **Style**
  * Standardized extension modal sizing using shared width variables (including the wide variant).
  * Updated the extension modal footer to use a theme-aware background color for consistent light/dark appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->