### PR TITLE
Remove insecure --security-opt label=disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Ready-to-use compose files live in [`docker-compose-examples/`](docker-compose-e
 ```bash
 # Set DEGOOG_SETTINGS_PASSWORDS before exposing this instance to the internet -
 # an unlocked instance lets anyone install extensions, which runs code on the server.
-podman run -d --name degoog -p 4444:4444 -v ./data:/app/data -e DEGOOG_SETTINGS_PASSWORDS=changeme --security-opt label=disable --restart unless-stopped ghcr.io/degoog-org/degoog:latest
+podman run -d --name degoog -p 4444:4444 -v ./data:/app/data:Z -e DEGOOG_SETTINGS_PASSWORDS=changeme --restart unless-stopped ghcr.io/degoog-org/degoog:latest
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Ready-to-use compose files live in [`docker-compose-examples/`](docker-compose-e
 ```bash
 # Set DEGOOG_SETTINGS_PASSWORDS before exposing this instance to the internet -
 # an unlocked instance lets anyone install extensions, which runs code on the server.
-podman run -d --name degoog -p 4444:4444 -v degoog:/app/data -e DEGOOG_SETTINGS_PASSWORDS=changeme --restart unless-stopped ghcr.io/degoog-org/degoog:latest
+podman run -d --name degoog -p 4444:4444 -v ./data:/app/data:Z -e DEGOOG_SETTINGS_PASSWORDS=changeme --restart unless-stopped ghcr.io/degoog-org/degoog:latest
 ```
 
 </details>
@@ -83,7 +83,7 @@ Environment=PGID=1000
 Environment=DEGOOG_SETTINGS_PASSWORDS=changeme
 # Environment=DEGOOG_PUBLIC_INSTANCE=true # Add if public
 UIDMap=+%U:@%U
-Volume=degoog:/app/data
+Volume=<Path to config>:/app/data:Z
 PublishPort=4444:4444
 Network=degoog
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Ready-to-use compose files live in [`docker-compose-examples/`](docker-compose-e
 ```bash
 # Set DEGOOG_SETTINGS_PASSWORDS before exposing this instance to the internet -
 # an unlocked instance lets anyone install extensions, which runs code on the server.
-podman run -d --name degoog -p 4444:4444 -v ./data:/app/data:Z -e DEGOOG_SETTINGS_PASSWORDS=changeme --restart unless-stopped ghcr.io/degoog-org/degoog:latest
+podman run -d --name degoog -p 4444:4444 -v degoog:/app/data -e DEGOOG_SETTINGS_PASSWORDS=changeme --restart unless-stopped ghcr.io/degoog-org/degoog:latest
 ```
 
 </details>
@@ -83,7 +83,7 @@ Environment=PGID=1000
 Environment=DEGOOG_SETTINGS_PASSWORDS=changeme
 # Environment=DEGOOG_PUBLIC_INSTANCE=true # Add if public
 UIDMap=+%U:@%U
-Volume=<Path to config>:/app/data:Z
+Volume=degoog:/app/data
 PublishPort=4444:4444
 Network=degoog
 


### PR DESCRIPTION
Remove the insecure --security-opt label=disable flag and add :Z to volume mounts for proper SELinux labeling.

The :Z flag relabels volumes for exclusive container access, providing the same permission isolation without disabling SELinux mandatory access control. This addresses issue #234.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Podman “Run” command in the setup instructions to improve SELinux compatibility by removing the `--security-opt label=disable` flag.
  * Added an explicit SELinux relabel option (`:Z`) on the bind mount (`./data:/app/data:Z`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->