### PR TITLE
Fixed issue with dev versioning

### DIFF
--- a/src/client/settings/general/tab.ts
+++ b/src/client/settings/general/tab.ts
@@ -21,7 +21,7 @@ import type { ToggleOpts } from "../../types/settings-section";
 import { renderCheckbox, renderSection } from "../shared/section";
 import { getBase } from "../../utils/base-url";
 import { authHeaders } from "../../utils/request";
-import { isUpdateAvailable } from "../../../server/utils/version";
+import { isUpdateAvailable } from "../../../shared/utils/version";
 
 const t = window.scopedT("core");
 

--- a/src/client/settings/general/tab.ts
+++ b/src/client/settings/general/tab.ts
@@ -21,6 +21,7 @@ import type { ToggleOpts } from "../../types/settings-section";
 import { renderCheckbox, renderSection } from "../shared/section";
 import { getBase } from "../../utils/base-url";
 import { authHeaders } from "../../utils/request";
+import { isUpdateAvailable } from "../../../server/utils/version";
 
 const t = window.scopedT("core");
 
@@ -329,7 +330,8 @@ async function initVersionChecker(): Promise<void> {
 
   if (lastCheckedEl) lastCheckedEl.textContent = latestDate.toLocaleDateString();
   const currentVersion = localStorage.getItem("last-update-check-version");
-  if (pkg.version !== currentVersion && newAvailableEl) newAvailableEl.removeAttribute("style");
+  if (currentVersion && isUpdateAvailable(pkg.version, currentVersion) && newAvailableEl)
+    newAvailableEl.removeAttribute("style");
 
   const latestVersion = localStorage.getItem("last-update-check-version");
   if (latestVersion && newestVersionEl) newestVersionEl.textContent = latestVersion;
@@ -341,7 +343,7 @@ async function initVersionChecker(): Promise<void> {
     const newLatest = new Date();
     localStorage.setItem("last-update-check", newLatest.toUTCString());
     if (lastCheckedEl) lastCheckedEl.textContent = newLatest.toLocaleDateString();
-    if (pkg.version !== newest && newAvailableEl && newest != "Unknown")
+    if (newest != "Unknown" && isUpdateAvailable(pkg.version, newest) && newAvailableEl)
       newAvailableEl.removeAttribute("style");
     else
       newAvailableEl?.setAttribute("style","display:none");

--- a/src/server/extensions/store/item-ops.ts
+++ b/src/server/extensions/store/item-ops.ts
@@ -1,7 +1,7 @@
 import { readFile, mkdir, readdir, stat, rm } from "fs/promises";
 import { join, resolve, dirname } from "path";
 import { removeSettings } from "../../utils/plugin-settings";
-import { isVersionAtLeast, getAppVersion } from "../../utils/version";
+import { isVersionAtLeast, getAppVersion } from "../../../shared/utils/version";
 import {
   ExtensionStoreType,
   type StoreItem,

--- a/src/server/routes/extensions.ts
+++ b/src/server/routes/extensions.ts
@@ -47,7 +47,7 @@ import { extensionReadmeExists } from "../utils/extension-docs";
 import { getInstalledItems, reloadAfterAction } from "../extensions/store/item-ops";
 import { makeExtID, folderFromExtID } from "../utils/extension-id";
 import { readObjectBody } from "../utils/hono";
-import { isVersionAtLeast, getAppVersion } from "../utils/version";
+import { isVersionAtLeast, getAppVersion } from "../../shared/utils/version";
 import { logger } from "../utils/logger";
 
 const router = new Hono();

--- a/src/server/utils/version.ts
+++ b/src/server/utils/version.ts
@@ -15,3 +15,27 @@ export const isVersionAtLeast = (current: string, required: string): boolean => 
   if (cMin !== rMin) return cMin > rMin;
   return cPatch >= rPatch;
 };
+
+const _parseDev = (v: string): number | null => {
+  const idx = v.indexOf("-dev");
+  if (idx === -1) return null;
+  const tail = v.slice(idx + 4).replace(/^[-.]/, "");
+  const n = parseFloat(tail);
+  return Number.isFinite(n) ? n : 0;
+};
+
+export const compareVersions = (a: string, b: string): number => {
+  const base = _parseSemver(a).map((x, i) => x - _parseSemver(b)[i]);
+  const diff = base.find((d) => d !== 0);
+  if (diff !== undefined) return diff > 0 ? 1 : -1;
+
+  const aDev = _parseDev(a);
+  const bDev = _parseDev(b);
+  if (aDev === null && bDev === null) return 0;
+  if (aDev === null) return 1;
+  if (bDev === null) return -1;
+  return aDev === bDev ? 0 : aDev > bDev ? 1 : -1;
+};
+
+export const isUpdateAvailable = (current: string, newest: string): boolean =>
+  compareVersions(newest, current) > 0;

--- a/src/shared/utils/version.ts
+++ b/src/shared/utils/version.ts
@@ -25,7 +25,8 @@ const _parseDev = (v: string): number | null => {
 };
 
 export const compareVersions = (a: string, b: string): number => {
-  const base = _parseSemver(a).map((x, i) => x - _parseSemver(b)[i]);
+  const bSemver = _parseSemver(b);
+  const base = _parseSemver(a).map((x, i) => x - bSemver[i]);
   const diff = base.find((d) => d !== 0);
   if (diff !== undefined) return diff > 0 ? 1 : -1;
 


### PR DESCRIPTION
Ordering holds: `0.23.0 < 0.24.0-dev-0.2 < 0.24.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update detection using shared semantic-version comparison, including correct handling of development/prerelease (`-dev`) suffixes.
  * Update notifications now appear only when a truly newer version is available, and the banner visibility logic was tightened for both “init” and “check now” flows.
  * Prevented misleading update banners caused by basic version-string inequality checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->