### PR TITLE
Fix baremetal restart issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ bun run start
 
 **note**: If running as a systemd service, set `Restart=on-failure` (or `always`) in the unit's
 `[Service]` section so restarts hand off to systemd instead of degoog's own self-respawn logic.
-This is auto-detected via `systemctl show`; if that's unavailable in your environment, set
-`DEGOOG_SYSTEMD_RESTART_CONFIGURED=true` in your `.env` to confirm it manually
+The policy is auto-detected; if it can't be confirmed, degoog falls back to respawning itself
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ bun run start
 
 **note**: If HTTPS requests fail with certificate errors, install the `ca-certificates` package
 
+**note**: If running as a systemd service, set `Restart=on-failure` (or `always`) in the unit's
+`[Service]` section so restarts hand off to systemd instead of degoog's own self-respawn logic.
+This is auto-detected via `systemctl show`; if that's unavailable in your environment, set
+`DEGOOG_SYSTEMD_RESTART_CONFIGURED=true` in your `.env` to confirm it manually
+
 </details>
 
 <details>

--- a/src/server/utils/server-lifecycle.ts
+++ b/src/server/utils/server-lifecycle.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "fs";
+import { existsSync } from "fs";
 import type { Subprocess, Server } from "bun";
 import { logger } from "./logger";
 import { closeAllDbs } from "../indexer/db";
@@ -17,13 +17,8 @@ export const registerServerHandle = (server: Server): void => {
 export const isDockerRuntime = (): boolean =>
   envTruthy("DEGOOG_DOCKER") || existsSync("/.dockerenv");
 
-export const isLXCRuntime = (): boolean => {
-  try {
-    return readFileSync("/run/systemd/container", "utf8").trim() === "lxc";
-  } catch {
-    return false;
-  }
-};
+/** systemd sets INVOCATION_ID for every service it supervises, so it will restart us on a non-zero exit */
+export const isSystemdService = (): boolean => Boolean(process.env.INVOCATION_ID);
 
 const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
 
@@ -35,7 +30,7 @@ const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
  * current one as you exit to give the illusion it's restarting.
  */
 const spawnReplacementProcess = (): Subprocess | undefined => {
-  if (isDockerRuntime() || isLXCRuntime()) return undefined;
+  if (isDockerRuntime() || isSystemdService()) return undefined;
 
   try {
     const child = Bun.spawn({
@@ -67,7 +62,7 @@ export const requestRestart = (reason: string): void => {
   clearRestartPending();
   setTimeout(() => {
     _serverHandle?.stop(true);
-    const exitCode = isLXCRuntime() ? 1 : 0;
+    const exitCode = isSystemdService() ? 1 : 0;
     const child = spawnReplacementProcess();
     stopQueue()
       .finally(async () => {

--- a/src/server/utils/server-lifecycle.ts
+++ b/src/server/utils/server-lifecycle.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import type { Subprocess, Server } from "bun";
 import { logger } from "./logger";
 import { closeAllDbs } from "../indexer/db";
@@ -17,8 +17,42 @@ export const registerServerHandle = (server: Server): void => {
 export const isDockerRuntime = (): boolean =>
   envTruthy("DEGOOG_DOCKER") || existsSync("/.dockerenv");
 
-/** systemd sets INVOCATION_ID for every service it supervises, so it will restart us on a non-zero exit */
+/** systemd sets INVOCATION_ID for every service it supervises, restart-on-failure or not */
 export const isSystemdService = (): boolean => Boolean(process.env.INVOCATION_ID);
+
+const SYSTEMD_RECOVERING_RESTART_POLICIES = new Set([
+  "always",
+  "on-failure",
+  "on-abnormal",
+  "on-watchdog",
+  "on-abort",
+]);
+
+/** Best-effort: resolve our own unit name from the cgroup path and ask systemd for its Restart= policy */
+const detectSystemdRestartPolicy = (): boolean => {
+  try {
+    const cgroup = readFileSync("/proc/self/cgroup", "utf8");
+    const unit = cgroup.match(/([\w.@-]+\.service)/)?.[1];
+    if (!unit) return false;
+
+    const result = Bun.spawnSync(["systemctl", "show", unit, "--property=Restart", "--value"]);
+    if (result.exitCode !== 0) return false;
+
+    const policy = result.stdout.toString().trim();
+    return SYSTEMD_RECOVERING_RESTART_POLICIES.has(policy);
+  } catch (err) {
+    logger.debug("server", "systemd restart policy detection failed", err);
+    return false;
+  }
+};
+
+/**
+ * INVOCATION_ID alone doesn't prove the unit has Restart=on-failure/always configured, so exiting
+ * non-zero and trusting systemd to bring us back is only safe once that's confirmed - either by
+ * auto-detecting the unit's actual policy, or by the user opting in when detection isn't possible.
+ */
+export const isSystemdRestartConfigured = (): boolean =>
+  envTruthy("DEGOOG_SYSTEMD_RESTART_CONFIGURED") || detectSystemdRestartPolicy();
 
 const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
 
@@ -30,7 +64,7 @@ const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
  * current one as you exit to give the illusion it's restarting.
  */
 const spawnReplacementProcess = (): Subprocess | undefined => {
-  if (isDockerRuntime() || isSystemdService()) return undefined;
+  if (isDockerRuntime() || (isSystemdService() && isSystemdRestartConfigured())) return undefined;
 
   try {
     const child = Bun.spawn({
@@ -62,7 +96,14 @@ export const requestRestart = (reason: string): void => {
   clearRestartPending();
   setTimeout(() => {
     _serverHandle?.stop(true);
-    const exitCode = isSystemdService() ? 1 : 0;
+    if (isSystemdService() && !isSystemdRestartConfigured()) {
+      logger.warn(
+        "server",
+        "running under systemd but couldn't confirm a recovering Restart= policy (auto-detect failed " +
+          "and DEGOOG_SYSTEMD_RESTART_CONFIGURED is not set); falling back to self-managed restart",
+      );
+    }
+    const exitCode = isSystemdService() && isSystemdRestartConfigured() ? 1 : 0;
     const child = spawnReplacementProcess();
     stopQueue()
       .finally(async () => {

--- a/src/server/utils/server-lifecycle.ts
+++ b/src/server/utils/server-lifecycle.ts
@@ -17,8 +17,16 @@ export const registerServerHandle = (server: Server): void => {
 export const isDockerRuntime = (): boolean =>
   envTruthy("DEGOOG_DOCKER") || existsSync("/.dockerenv");
 
-/** systemd sets INVOCATION_ID for every service it supervises, restart-on-failure or not */
-export const isSystemdService = (): boolean => Boolean(process.env.INVOCATION_ID);
+export const isLXCRuntime = (): boolean => {
+  try {
+    return readFileSync("/run/systemd/container", "utf8").trim() === "lxc";
+  } catch {
+    return false;
+  }
+};
+
+export const isSystemdService = (): boolean =>
+  Boolean(process.env.INVOCATION_ID) || isLXCRuntime();
 
 const SYSTEMD_RECOVERING_RESTART_POLICIES = new Set([
   "always",
@@ -28,11 +36,9 @@ const SYSTEMD_RECOVERING_RESTART_POLICIES = new Set([
   "on-abort",
 ]);
 
-/** Best-effort: resolve our own unit name from the cgroup path and ask systemd for its Restart= policy */
-const detectSystemdRestartPolicy = (): boolean => {
+export const isSystemdRestartConfigured = (): boolean => {
   try {
     const cgroup = readFileSync("/proc/self/cgroup", "utf8");
-    /* fccview is onto you! nested slices mean the leaf component is our unit, not the first match */
     const unit = cgroup
       .split(/[\n/]/)
       .filter((part) => /^[\w.@-]+\.service$/.test(part))
@@ -49,14 +55,6 @@ const detectSystemdRestartPolicy = (): boolean => {
     return false;
   }
 };
-
-/**
- * INVOCATION_ID alone doesn't prove the unit has Restart=on-failure/always configured, so exiting
- * non-zero and trusting systemd to bring us back is only safe once that's confirmed - either by
- * auto-detecting the unit's actual policy, or by the user opting in when detection isn't possible.
- */
-export const isSystemdRestartConfigured = (): boolean =>
-  envTruthy("DEGOOG_SYSTEMD_RESTART_CONFIGURED") || detectSystemdRestartPolicy();
 
 const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
 
@@ -105,8 +103,8 @@ export const requestRestart = (reason: string): void => {
     if (underSystemd && !systemdWillRestart) {
       logger.warn(
         "server",
-        "running under systemd but couldn't confirm a recovering Restart= policy (auto-detect failed " +
-          "and DEGOOG_SYSTEMD_RESTART_CONFIGURED is not set); falling back to self-managed restart",
+        "running under systemd but couldn't confirm a recovering Restart= policy; " +
+          "falling back to self-managed restart",
       );
     }
     const exitCode = systemdWillRestart ? 1 : 0;

--- a/src/server/utils/server-lifecycle.ts
+++ b/src/server/utils/server-lifecycle.ts
@@ -32,7 +32,11 @@ const SYSTEMD_RECOVERING_RESTART_POLICIES = new Set([
 const detectSystemdRestartPolicy = (): boolean => {
   try {
     const cgroup = readFileSync("/proc/self/cgroup", "utf8");
-    const unit = cgroup.match(/([\w.@-]+\.service)/)?.[1];
+    /* fccview is onto you! nested slices mean the leaf component is our unit, not the first match */
+    const unit = cgroup
+      .split(/[\n/]/)
+      .filter((part) => /^[\w.@-]+\.service$/.test(part))
+      .pop();
     if (!unit) return false;
 
     const result = Bun.spawnSync(["systemctl", "show", unit, "--property=Restart", "--value"]);
@@ -63,8 +67,8 @@ const hasControllingTerminal = (): boolean => Boolean(process.stdout.isTTY);
  * On native runs, proxmox or whatever shit you all run this stuff on, I'm gonna spawn a new process to replace the
  * current one as you exit to give the illusion it's restarting.
  */
-const spawnReplacementProcess = (): Subprocess | undefined => {
-  if (isDockerRuntime() || (isSystemdService() && isSystemdRestartConfigured())) return undefined;
+const spawnReplacementProcess = (systemdWillRestart: boolean): Subprocess | undefined => {
+  if (isDockerRuntime() || systemdWillRestart) return undefined;
 
   try {
     const child = Bun.spawn({
@@ -96,15 +100,17 @@ export const requestRestart = (reason: string): void => {
   clearRestartPending();
   setTimeout(() => {
     _serverHandle?.stop(true);
-    if (isSystemdService() && !isSystemdRestartConfigured()) {
+    const underSystemd = isSystemdService();
+    const systemdWillRestart = underSystemd && isSystemdRestartConfigured();
+    if (underSystemd && !systemdWillRestart) {
       logger.warn(
         "server",
         "running under systemd but couldn't confirm a recovering Restart= policy (auto-detect failed " +
           "and DEGOOG_SYSTEMD_RESTART_CONFIGURED is not set); falling back to self-managed restart",
       );
     }
-    const exitCode = isSystemdService() && isSystemdRestartConfigured() ? 1 : 0;
-    const child = spawnReplacementProcess();
+    const exitCode = systemdWillRestart ? 1 : 0;
+    const child = spawnReplacementProcess(systemdWillRestart);
     stopQueue()
       .finally(async () => {
         await closeAllDbs();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart handling for systemd-managed deployments.
  * Prevented unnecessary replacement processes when systemd or Docker can automatically recover the service.
  * Systemd restarts now use the expected exit status when recovery is confirmed.
  * Added safer fallback behavior when restart settings cannot be detected.

* **Documentation**
  * Added guidance for configuring native systemd services with automatic restart policies.
  * Documented automatic restart-policy detection and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->