### PR TITLE
fix the broken star history chart in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ Alternatives are what make the internet a fun place, let me share a few other ag
 | OmniSearch | https://git.bwaaa.monster/omnisearch |
 | LibreY     | https://github.com/Ahwxorg/LibreY    |
 
-[![Star History Chart](https://api.star-history.com/image?repos=degoog-org/degoog&type=date&legend=top-left)](https://www.star-history.com/?repos=fccview%2Fdegoog&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=degoog-org/degoog&type=date&legend=top-left)](https://star-history.dera.page/#degoog-org/degoog&type=date&legend=top-left)


### PR DESCRIPTION
the star history chart in the readme is broken because github keeps limiting their stargazer api, so the old provider can't do its job anymore. moved it to a provider that works without an api token. also updated the repo owner in the links since the repo moved from fccview/degoog to degoog-org/degoog, those were gonna 404 sooner or later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart to use the current project repository and chart service link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->