### PR TITLE
fix(store): use path.sep instead of hardcoded slash for Windows compatibility

### DIFF
--- a/src/server/extensions/store/item-ops.ts
+++ b/src/server/extensions/store/item-ops.ts
@@ -1,5 +1,6 @@
 import { readFile, mkdir, readdir, stat, rm } from "fs/promises";
-import { join, resolve, dirname, sep } from "path";
+import { join, resolve, dirname } from "path";
+import { resolveContained } from "../../utils/paths";
 import { removeSettings } from "../../utils/plugin-settings";
 import { isVersionAtLeast, getAppVersion } from "../../../shared/utils/version";
 import {
@@ -551,9 +552,9 @@ async function _installItem(
   _installingSet.add(key);
   try {
     const storeDir = getStoreDir();
-    const srcDir = join(storeDir, repo.localPath, normalizedPath);
     const repoBase = resolve(join(storeDir, repo.localPath));
-    if (!resolve(srcDir).startsWith(repoBase + sep))
+    const srcDir = resolveContained(repoBase, normalizedPath);
+    if (!srcDir || srcDir === repoBase)
       throw new Error("Invalid item path.");
     try {
       await stat(srcDir);
@@ -766,9 +767,8 @@ async function _deleteUntracked(
   folderName: string,
 ): Promise<void> {
   const base = resolve(STORE_TYPE_SPECS[type].destDir());
-  const target = resolve(join(base, folderName));
-  if (!target.startsWith(base + sep))
-    throw new Error("Invalid folder name.");
+  const target = resolveContained(base, folderName);
+  if (!target || target === base) throw new Error("Invalid folder name.");
   await rm(target, { recursive: true, force: true });
   await reloadAfterAction(type);
 }

--- a/src/server/extensions/store/item-ops.ts
+++ b/src/server/extensions/store/item-ops.ts
@@ -1,5 +1,5 @@
 import { readFile, mkdir, readdir, stat, rm } from "fs/promises";
-import { join, resolve, dirname } from "path";
+import { join, resolve, dirname, sep } from "path";
 import { removeSettings } from "../../utils/plugin-settings";
 import { isVersionAtLeast, getAppVersion } from "../../../shared/utils/version";
 import {
@@ -553,7 +553,7 @@ async function _installItem(
     const storeDir = getStoreDir();
     const srcDir = join(storeDir, repo.localPath, normalizedPath);
     const repoBase = resolve(join(storeDir, repo.localPath));
-    if (!resolve(srcDir).startsWith(repoBase + "/"))
+    if (!resolve(srcDir).startsWith(repoBase + sep))
       throw new Error("Invalid item path.");
     try {
       await stat(srcDir);
@@ -767,7 +767,7 @@ async function _deleteUntracked(
 ): Promise<void> {
   const base = resolve(STORE_TYPE_SPECS[type].destDir());
   const target = resolve(join(base, folderName));
-  if (!target.startsWith(base + "/"))
+  if (!target.startsWith(base + sep))
     throw new Error("Invalid folder name.");
   await rm(target, { recursive: true, force: true });
   await reloadAfterAction(type);


### PR DESCRIPTION
## Problem

Installing extensions from the store on Windows fails with `Invalid item path` error.

## Root Cause

In `src/server/extensions/store/item-ops.ts`, path validation used a hardcoded forward slash for the `startsWith()` check:

```
if (!resolve(srcDir).startsWith(repoBase + "/"))
  throw new Error("Invalid item path.");
```

On Windows, `resolve()` returns paths with backslashes, so the comparison always fails.

## Fix

- Import `sep` from `path` (the platform-specific separator)
- Replace `repoBase + "/"` with `repoBase + sep` in `_installItem`
- Replace `base + "/"` with `base + sep` in `_deleteUntracked`

## Testing

- Verified the fix resolves the `Invalid item path` error on Windows
- Build passes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path validation across platforms when installing extensions and deleting untracked items.
  * Invalid paths and attempts to target repository or base-directory locations continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->