### PR TITLE
Add a Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/public/app.js
 src/public/settings-page.js
 data/
 data_bak/
+result
 stores
 dist
 mcp

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,141 @@
+{
+  "nodes": {
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1782772816,
+        "narHash": "sha256-s9BuFv0mRuZx9C1MF8qPHRdcAK14ONi0A5m6E2wqOoM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "5a39d717029e94163ac223aee8d5c9946cafed1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Nix flake for Degoog";
+
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    bun2nix = {
+      url = "github:nix-community/bun2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      imports = [ ./third-party/nix ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    };
+}

--- a/third-party/nix/default.nix
+++ b/third-party/nix/default.nix
@@ -1,0 +1,82 @@
+{ self, inputs, ... }:
+{
+  perSystem =
+    {
+      pkgs,
+      system,
+      lib,
+      ...
+    }:
+    let
+      commonModule = { lib, ... }: {
+        imports = [
+          self.nixosModules.default
+        ];
+
+        services.degoog = {
+          enable = true;
+          configurePostgres = true;
+
+          environment = {
+            DEGOOG_DANGEROUSLY_NO_PASSWORD = true;
+            DEGOOG_PUBLIC_INSTANCE = false;
+            DEGOOG_WIZARD = false;
+            LOG_LEVEL = "debug";
+          };
+        };
+      };
+
+      nixosConfiguration = inputs.nixpkgs.lib.nixosSystem {
+        inherit system;
+
+        modules = [
+          commonModule
+          "${inputs.nixpkgs}/nixos/modules/virtualisation/qemu-vm.nix"
+          {
+            networking.firewall.enable = false;
+            services.getty.autologinUser = "root";
+
+            virtualisation = {
+              diskImage = null;
+
+              forwardPorts = [
+                {
+                  from = "host";
+                  host.port = 4444;
+                  guest.port = 4444;
+                }
+              ];
+            };
+          }
+        ];
+      };
+    in
+    {
+      checks.module = pkgs.testers.runNixOSTest {
+        name = "degoog";
+
+        nodes.machine = commonModule;
+
+        testScript = ''
+          start_all()
+
+          with subtest("start degoog"):
+            machine.wait_for_unit("degoog.service")
+            machine.wait_for_open_port(4444)
+        '';
+      };
+
+      apps.run-in-vm = {
+        type = "app";
+
+        program = lib.getExe nixosConfiguration.config.system.build.vm;
+      };
+
+      packages.default = pkgs.callPackage ./package.nix {
+        bun2nix = inputs.bun2nix.packages.${system}.default;
+        src = inputs.self;
+      };
+    };
+
+  flake.nixosModules.default = import ./module.nix self;
+}

--- a/third-party/nix/module.nix
+++ b/third-party/nix/module.nix
@@ -1,0 +1,346 @@
+self:
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkEnableOption
+    mkPackageOption
+    optional
+    optionalAttrs
+    boolToString
+    types
+    ;
+
+  inherit (types)
+    attrsOf
+    bool
+    nullOr
+    path
+    port
+    str
+    submodule
+    oneOf
+    int
+    ;
+
+  cfg = config.services.degoog;
+in
+{
+  options.services.degoog = {
+    enable = mkEnableOption "Degoog, a search engine aggregator with a comprehensive plugin/extension system";
+
+    package = mkPackageOption self.packages.${pkgs.stdenv.hostPlatform.system} "default" { };
+
+    environmentFile = mkOption {
+      type = nullOr path;
+      default = null;
+      example = "/run/secrets/degoog.env";
+      description = "EnvironmentFile as defined in {manpage}`systemd.exec(5)`.";
+    };
+
+    configurePostgres = mkEnableOption "PostgreSQL locally using services.postgresql";
+
+    environment = mkOption {
+      description = ''
+        Environment variables used to configure Degoog.
+
+        Any environment variable supported by Degoog may be specified,
+        even if it is not explicitly declared by this module.
+      '';
+
+      type = submodule {
+        freeformType = attrsOf (
+          nullOr (oneOf [
+            str
+            bool
+            path
+            int
+          ])
+        );
+
+        options = {
+          DEGOOG_PORT = mkOption {
+            type = port;
+            default = 4444;
+            description = "The port Degoog listens on.";
+            example = 8080;
+          };
+
+          DEGOOG_UNIX_SOCKET = mkOption {
+            type = nullOr path;
+            default = null;
+            description = "Path to a Unix socket for Degoog to listen on.";
+            example = "/run/degoog/degoog.sock";
+          };
+
+          DEGOOG_BASE_URL = mkOption {
+            type = str;
+            default = "";
+            description = ''
+              Base URL when hosting Degoog under a path.
+
+              For example, `/degoog` when Degoog is served from `https://example.com/degoog`.
+            '';
+            example = "/degoog";
+          };
+
+          DEGOOG_WIZARD = mkOption {
+            type = bool;
+            default = false;
+            description = "Whether to enable the startup wizard.";
+            example = true;
+          };
+
+          DEGOOG_DISTRUST_PROXY = mkOption {
+            type = bool;
+            default = false;
+            description = "Whether Degoog should distrust incoming reverse proxy connections.";
+            example = true;
+          };
+
+          DEGOOG_PUBLIC_INSTANCE = mkOption {
+            type = bool;
+            default = true;
+            description = "Whether this is a public Degoog instance.";
+            example = false;
+          };
+
+          DEGOOG_SETTINGS_PASSWORDS = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Password used to protect Degoog settings.
+
+              It is recommended to provide this through {option}`services.degoog.environmentFile` rather than putting it directly in the Nix configuration.
+            '';
+            example = "changeme";
+          };
+
+          DEGOOG_DANGEROUSLY_NO_PASSWORD = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Disable the settings password protection.
+
+              This is dangerous for publicly accessible instances.
+            '';
+            example = false;
+          };
+
+          DEGOOG_POSTGRES = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "PostgreSQL connection URL used by Degoog.";
+            example = "postgresql://degoog:changeme@localhost:5432/degoog";
+          };
+
+          DEGOOG_POSTGRES_HOST = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              PostgreSQL host used by Degoog, as an alternative to
+              {option}`services.degoog.environment.DEGOOG_POSTGRES`.
+              Useful when your deployment hands you credentials as
+              individual keys, such as a Kubernetes secret (CNPG,
+              bjw-s app-template). `DEGOOG_POSTGRES` wins when both
+              are set.
+              A host starting with `/` is a Unix socket (peer auth,
+              no password), which a URL cannot express.
+            '';
+            example = "degoog-postgres";
+          };
+
+          DEGOOG_POSTGRES_PORT = mkOption {
+            type = nullOr port;
+            default = null;
+            description = "PostgreSQL port used by Degoog.";
+            example = 5432;
+          };
+
+          DEGOOG_POSTGRES_USER = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "PostgreSQL user used by Degoog.";
+            example = "degoog";
+          };
+
+          DEGOOG_POSTGRES_PASSWORD = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              PostgreSQL password used by Degoog.
+              It is recommended to provide this through
+              {option}`services.degoog.environmentFile` rather than
+              putting it directly in the Nix configuration.
+            '';
+            example = "changeme";
+          };
+
+          DEGOOG_POSTGRES_DATABASE = mkOption {
+            type = nullOr str;
+            default = null;
+            description = "PostgreSQL database used by Degoog.";
+            example = "degoog";
+          };
+        };
+      };
+
+      default = { };
+
+      example = {
+        DEGOOG_PORT = 8080;
+        DEGOOG_WIZARD = false;
+        DEGOOG_DISTRUST_PROXY = true;
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion =
+          !cfg.configurePostgres
+          || !(lib.any (name: lib.hasPrefix "DEGOOG_POSTGRES" name && cfg.environment.${name} != null) (
+            builtins.attrNames cfg.environment
+          ));
+
+        message = ''
+          `services.degoog.configurePostgres` cannot be used together with
+          `services.degoog.environment.DEGOOG_POSTGRES` or any of the
+          `services.degoog.environment.DEGOOG_POSTGRES_*` options.
+
+          Disable `configurePostgres` if you want to provide your own
+          PostgreSQL connection details.
+        '';
+      }
+    ];
+
+    services.postgresql = mkIf cfg.configurePostgres {
+      enable = true;
+
+      ensureDatabases = [
+        "degoog"
+      ];
+
+      ensureUsers = [
+        {
+          name = "degoog";
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    systemd.services.degoog = {
+      description = "Degoog, a search engine aggregator with a comprehensive plugin/extension system";
+
+      after = [
+        "network-online.target"
+      ]
+      ++ optional cfg.configurePostgres "postgresql.service";
+
+      wants = [
+        "network-online.target"
+      ];
+
+      wantedBy = [
+        "multi-user.target"
+      ];
+
+      environment =
+        lib.mapAttrs (_: value: if builtins.isBool value then boolToString value else toString value) (
+          lib.filterAttrs (_: value: value != null) cfg.environment
+        )
+        // {
+          BUN_INSTALL_CACHE_DIR = "/tmp/bun";
+          DEGOOG_DATA_DIR = toString config.systemd.services.degoog.serviceConfig.WorkingDirectory;
+        }
+        // optionalAttrs cfg.configurePostgres {
+          DEGOOG_POSTGRES_HOST = "/var/run/postgresql";
+          DEGOOG_POSTGRES_USER = "degoog";
+        };
+
+      serviceConfig = {
+        Type = "simple";
+
+        WorkingDirectory = "/var/lib/degoog";
+        StateDirectory = "degoog";
+        RuntimeDirectory = "degoog";
+
+        ExecStart = lib.getExe cfg.package;
+
+        Restart = "on-failure";
+        TimeoutSec = 15;
+
+        EnvironmentFile = cfg.environmentFile;
+
+        NoNewPrivileges = true;
+        SystemCallArchitectures = "native";
+
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+
+        RuntimeDirectoryMode = "0770";
+        UMask = "0007";
+
+        PrivateUsers = true;
+        DynamicUser = true;
+
+        RestrictNamespaces = !config.boot.isContainer;
+        RestrictRealtime = true;
+        RestrictSUIDSGID = true;
+
+        ProtectControlGroups = !config.boot.isContainer;
+        ProtectSystem = "strict";
+        ProtectHostname = true;
+        ProtectKernelLogs = !config.boot.isContainer;
+        ProtectKernelModules = !config.boot.isContainer;
+        ProtectKernelTunables = !config.boot.isContainer;
+        ProtectClock = true;
+
+        ProtectProc = "noaccess";
+        ProcSubset = "pid";
+
+        ProtectHome = true;
+
+        CapabilityBoundingSet = "";
+
+        LockPersonality = true;
+
+        PrivateTmp = !config.boot.isContainer;
+        PrivateDevices = true;
+        RemoveIPC = true;
+
+        SystemCallFilter = [
+          "~@clock"
+          "~@aio"
+          "~@chown"
+          "~@cpu-emulation"
+          "~@debug"
+          "~@keyring"
+          "~@memlock"
+          "~@module"
+          "~@mount"
+          "~@obsolete"
+          "~@privileged"
+          "~@raw-io"
+          "~@reboot"
+          "~@setuid"
+          "~@swap"
+          "~@resources"
+        ];
+
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+  };
+}

--- a/third-party/nix/package.nix
+++ b/third-party/nix/package.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  src,
+  git,
+  runCommandLocal,
+  bun2nix,
+  ...
+}:
+bun2nix.writeBunApplication {
+  inherit src;
+  packageJson = "${src}/package.json";
+
+  buildPhase = "bun run build";
+
+  startScript = "bun run start";
+
+  bunDeps = bun2nix.fetchBunDeps {
+    bunNix = runCommandLocal "fetch-degoog-deps" { } ''
+      ${lib.getExe bun2nix} --lock-file ${src}/bun.lock --output-file $out
+    '';
+  };
+
+  runtimeInputs = [
+    git
+  ];
+
+  meta = {
+    description = "Search engine aggregator with a comprehensive plugin/extension system";
+    homepage = "https://github.com/degoog-org/degoog";
+    license = lib.licenses.agpl3Only;
+    maintainers = [ lib.maintainers.quadradical ];
+  };
+}


### PR DESCRIPTION
Adds a Nix flake including a module, checks, and a VM app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Nix flake support for building and running Degoog on Linux systems.
  - Added a configurable NixOS service with environment file support and optional PostgreSQL setup.
  - Added a packaged Degoog application for reproducible deployment.
  - Added a virtual machine configuration for local evaluation, including access through port 4444.

- **Tests**
  - Added an automated NixOS check verifying that the service starts and is reachable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->