### PR TITLE
Fix issue with displaying disabled settings

### DIFF
--- a/src/server/extensions/autocomplete/registry.ts
+++ b/src/server/extensions/autocomplete/registry.ts
@@ -194,8 +194,8 @@ export async function getSuggestionsFromProviders(query: string): Promise<
 }
 
 export async function getAutocompleteExtensionMeta(): Promise<ExtensionMeta[]> {
-  const transportOptions = getTransportNames();
-  const transportLabels = getTransportDisplayNames();
+  const transportOptions = await getTransportNames();
+  const transportLabels = await getTransportDisplayNames();
   const results: ExtensionMeta[] = [];
 
   for (const p of _all()) {

--- a/src/server/extensions/engines/registry.ts
+++ b/src/server/extensions/engines/registry.ts
@@ -468,8 +468,8 @@ export const getEngineExtensionMeta = async (
   const items = allEngineEntries();
   const engineMap = getEngineMap();
   const results: ExtensionMeta[] = [];
-  const transportOptions = getTransportNames();
-  const transportLabels = getTransportDisplayNames();
+  const transportOptions = await getTransportNames();
+  const transportLabels = await getTransportDisplayNames();
 
   const baseScoreField = coreT
     ? {

--- a/src/server/extensions/transports/registry.ts
+++ b/src/server/extensions/transports/registry.ts
@@ -73,12 +73,22 @@ export function getTransport(name: string): Transport | undefined {
   return _all().find((t) => t.name === name);
 }
 
-export function getTransportNames(): string[] {
-  return _all().map((t) => t.name);
+// Non-builtin transports can be disabled; keep those out of pickers.
+const _enabledTransports = async (): Promise<Transport[]> => {
+  const results: Transport[] = [];
+  for (const t of _all()) {
+    const settings = await getSettings(t.name);
+    if (settings["disabled"] !== "true") results.push(t);
+  }
+  return results;
+};
+
+export async function getTransportNames(): Promise<string[]> {
+  return (await _enabledTransports()).map((t) => t.name);
 }
 
-export function getTransportDisplayNames(): string[] {
-  return _all().map((t) => t.displayName ?? t.name);
+export async function getTransportDisplayNames(): Promise<string[]> {
+  return (await _enabledTransports()).map((t) => t.displayName ?? t.name);
 }
 
 export const getAvailableTransportNames = async (): Promise<string[]> => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled transports are now excluded from transport name and display-name listings.
  - Autocomplete and engine extension metadata now correctly reflects the available transport list.
  - Transport information is loaded asynchronously to ensure listings use current settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->