### PR TITLE
feat: add NixOS module to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ docker run -d --name degoog -p 4444:4444 -v ./data:/app/data -e DEGOOG_SETTINGS_
 </details>
 
 <details>
+<summary>NixOS Module</summary>
+
+Degoog has a Nix flake including a package and NixOS module. Add it to your flake's `inputs`:
+
+```nix
+degoog = {
+  url = "github:degoog-org/degoog";
+  inputs.nixpkgs.follows = "nixpkgs";
+};
+```
+
+Then, import and configure the module:
+
+```nix
+imports = [ inputs.degoog.nixosModules.default ];
+
+services.degoog = {
+  enable = true;
+  configurePostgres = true;
+
+  environment = {
+    DEGOOG_UNIX_SOCKET = "/var/run/degoog/degoog.sock";
+	# Other environment variables can be found at https://degoog-org.github.io/docs/environment-variables.html
+  };
+
+  # Other option definitions can be found at https://github.com/degoog-org/degoog/blob/main/third-party/nix/module.nix
+};
+```
+
+</details>
+
+<details>
 <summary>Run natively</summary>
 
 You'll need a `.env` file for your env variables and the following required dependencies:


### PR DESCRIPTION
Adds a NixOS module example to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a README section explaining how to integrate the application as a NixOS module.
  - Documented how to add the flake as an input and import the module.
  - Documented available service configuration options, environment settings, including the Unix socket setting, and PostgreSQL setup.
  - Added references to environment-variable and module documentation.
  - Corrected the configuration example so it can be copied and parsed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->