### PR TITLE
Make slots work on other search type as per user choice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ The contract that community authors code against is wider than it looks:
 - Canonical IDs from `makeExtID`, which is `{folder}-{kind}`. Every settings key, the enabled-engine map, the active theme and every shortcut binding hang off these strings.
 - Export names the registries match on: `executeSearch`, `getSuggestions`, `intercept`, `trigger` and `execute`, `fetch`, `run`, `plugin`, `routes`, `searchBarActions`.
 - Context fields those hooks receive: `ctx.fetch`, `ctx.signProxyUrl`, `ctx.useCache`, `ctx.sentinel`, `ctx.pluginId`, `ctx.apiBase`.
-- Reserved settings keys: `disabled`, `outgoingTransport`, `searchTypeOverride`, `slotPosition`, `priority`, `score`, `theme`, `shortcuts`.
+- Reserved settings keys: `disabled`, `outgoingTransport`, `searchTypeOverride`, `slotPosition`, `slotSearchTypes`, `priority`, `score`, `theme`, `shortcuts`.
 - Slot position strings, `data-slot`, the `degoog-*` template keys and the DOM IDs that shortcuts and themes query from the browser.
 - `/api/plugin/<folder>/` and the injected `__PLUGIN_ID__`.
 

--- a/src/client/modules/modals/settings-modal/modal-fields.ts
+++ b/src/client/modules/modals/settings-modal/modal-fields.ts
@@ -7,6 +7,7 @@ import {
   renderFileField,
 } from "./field-widgets";
 import { renderOptionsList, wrapOptionsRow } from "./options-field";
+import { renderMultiField } from "./multiselect-field";
 import type { SettingField, ExtensionMeta } from "../../../types";
 
 const t = window.scopedT("core");
@@ -75,6 +76,12 @@ export function readLiveSettingFieldValue(
   if (type === "list") {
     const hidden = fieldEl.querySelector<HTMLInputElement>(
       ".ext-field-list-value",
+    );
+    return hidden?.value?.trim() ?? "";
+  }
+  if (type === "multiselect") {
+    const hidden = fieldEl.querySelector<HTMLInputElement>(
+      ".ext-field-multiselect-value",
     );
     return hidden?.value?.trim() ?? "";
   }
@@ -288,6 +295,10 @@ export const renderField = (
 
   if (field.type === "list") {
     return _wrapVisibleWhen(field, renderListField(field, ext), ext);
+  }
+
+  if (field.type === "multiselect") {
+    return _wrapVisibleWhen(field, renderMultiField(field, ext, descHtml), ext);
   }
 
   if (field.type === "hex") {

--- a/src/client/modules/modals/settings-modal/modal.ts
+++ b/src/client/modules/modals/settings-modal/modal.ts
@@ -1,5 +1,6 @@
 import { renderField, initUrlList, syncConditionalFields } from "./modal-fields";
 import { initListFields } from "./list-field";
+import { initMultiFields } from "./multiselect-field";
 import {
   initHexFields,
   initRangeFields,
@@ -129,6 +130,16 @@ const _collectValues = (): Record<string, string | string[]> => {
       values[key] = hidden?.value?.trim() || "[]";
       return;
     }
+    if (type === "multiselect") {
+      const hidden = fieldEl.querySelector<HTMLInputElement>(
+        ".ext-field-multiselect-value",
+      );
+      values[key] = (hidden?.value ?? "")
+        .split(",")
+        .map((v) => v.trim())
+        .filter(Boolean);
+      return;
+    }
     if (type === "file") {
       const hidden = fieldEl.querySelector<HTMLInputElement>(
         ".ext-field-file-value",
@@ -164,6 +175,13 @@ const _advancedFieldDiffersFromDefault = (
 
   if (field.type === "urllist") {
     return Array.isArray(raw) && raw.length > 0;
+  }
+
+  if (field.type === "multiselect") {
+    const picked = Array.isArray(raw) ? raw : String(raw ?? "").split(",");
+    const chosen = picked.map((v) => v.trim()).filter(Boolean);
+    const def = defaultStr.split(",").map((v) => v.trim()).filter(Boolean);
+    return chosen.slice().sort().join(",") !== def.slice().sort().join(",");
   }
 
   if (field.type === "list") {
@@ -282,6 +300,7 @@ export function openModal(ext: ExtensionMeta): void {
     initOptionsFields(bodyEl, ext.id, _collectValues);
     initUrlList(bodyEl);
     initListFields(bodyEl, ext.id);
+    initMultiFields(bodyEl);
     initHexFields(bodyEl);
     initRangeFields(bodyEl);
     initFileFields(bodyEl, ext.id);

--- a/src/client/modules/modals/settings-modal/multiselect-field.ts
+++ b/src/client/modules/modals/settings-modal/multiselect-field.ts
@@ -1,0 +1,62 @@
+import { escapeHtml } from "../../../utils/dom";
+import { parseTypeList } from "../../../../shared/search-types";
+import type { SettingField, ExtensionMeta } from "../../../types";
+
+const FIELD_CLASS = "ext-field-multiselect";
+const CHIP_CLASS = "ext-field-multiselect-chip";
+const VALUE_CLASS = "ext-field-multiselect-value";
+const CHIP_ON_CLASS = "ext-field-multiselect-chip--on";
+
+const _chosen = (field: SettingField, ext: ExtensionMeta): string[] => {
+  const stored = ext.settings[field.key];
+  const picked = parseTypeList(stored);
+  return picked.length > 0 ? picked : parseTypeList(field.default);
+};
+
+export const renderMultiField = (
+  field: SettingField,
+  ext: ExtensionMeta,
+  descHtml: string,
+): string => {
+  const options = field.options ?? [];
+  const picked = new Set(_chosen(field, ext));
+  const chips = options
+    .map((value, at) => {
+      const label = field.optionLabels?.[at] ?? value;
+      const on = picked.has(value);
+      return `<button type="button" class="${CHIP_CLASS}${on ? ` ${CHIP_ON_CLASS}` : ""}" data-value="${escapeHtml(value)}" aria-pressed="${on}">${escapeHtml(label)}</button>`;
+    })
+    .join("");
+  const initial = options.filter((value) => picked.has(value));
+  return `<div class="ext-field" data-key="${escapeHtml(field.key)}" data-type="multiselect">
+      <label class="ext-field-label">${escapeHtml(field.label)}</label>
+      <div class="${FIELD_CLASS}" role="group" aria-label="${escapeHtml(field.label)}">${chips}</div>
+      <input type="hidden" id="field-${escapeHtml(field.key)}" class="${VALUE_CLASS}" value="${escapeHtml(initial.join(","))}">
+      ${descHtml}
+    </div>`;
+};
+
+export const initMultiFields = (container: HTMLElement): void => {
+  container
+    .querySelectorAll<HTMLElement>(".ext-field[data-type='multiselect']")
+    .forEach((fieldEl) => {
+      const hidden = fieldEl.querySelector<HTMLInputElement>(`.${VALUE_CLASS}`);
+      if (!hidden) return;
+
+      const sync = (): void => {
+        const on = [
+          ...fieldEl.querySelectorAll<HTMLElement>(`.${CHIP_ON_CLASS}`),
+        ].map((chip) => chip.dataset.value ?? "");
+        hidden.value = on.filter(Boolean).join(",");
+        hidden.dispatchEvent(new Event("change", { bubbles: true }));
+      };
+
+      fieldEl.querySelectorAll<HTMLElement>(`.${CHIP_CLASS}`).forEach((chip) => {
+        chip.addEventListener("click", () => {
+          const on = chip.classList.toggle(CHIP_ON_CLASS);
+          chip.setAttribute("aria-pressed", String(on));
+          sync();
+        });
+      });
+    });
+};

--- a/src/client/types/extension.ts
+++ b/src/client/types/extension.ts
@@ -15,6 +15,7 @@ export type SettingFieldType =
   | "toggle"
   | "textarea"
   | "select"
+  | "multiselect"
   | "urllist"
   | "list"
   | "hex"

--- a/src/client/utils/engines.ts
+++ b/src/client/utils/engines.ts
@@ -78,11 +78,7 @@ export const getKnownSearchTypePrefixes = async (): Promise<Set<string>> => {
   return prefixes;
 };
 
-export const resolveBuiltinSearchType = (type: string): string => {
-  if (type.startsWith("tab:engine:")) return type.slice("tab:engine:".length);
-  if (type.startsWith("engine:")) return type.slice("engine:".length);
-  return type;
-};
-
-export const isImageSearchType = (type: string): boolean =>
-  resolveBuiltinSearchType(type) === "images";
+export {
+  resolveBuiltinSearchType,
+  isImageSearchType,
+} from "../../shared/search-types";

--- a/src/client/utils/search-utils.ts
+++ b/src/client/utils/search-utils.ts
@@ -42,12 +42,12 @@ export const abortSlotPanels = (): void => {
 const _slotRequestBody = (
   query: string,
   results?: ScoredResult[],
-): string =>
-  JSON.stringify(
-    results !== undefined
-      ? { query: query.trim(), results }
-      : { query: query.trim() },
+): string => {
+  const base = { query: query.trim(), type: state.currentType };
+  return JSON.stringify(
+    results !== undefined ? { ...base, results } : base,
   );
+};
 
 const _renderGlanceHtml = (panels: SlotPanel[], clearIfEmpty: boolean): void => {
   const glanceEl = document.getElementById("at-a-glance");

--- a/src/client/utils/search/search-actions-page.ts
+++ b/src/client/utils/search/search-actions-page.ts
@@ -81,10 +81,11 @@ export async function goToPage(pageNum: number): Promise<void> {
     const metaText = `About ${state.currentResults.length} results - Page ${state.currentPage}`;
     setResultsMeta(metaText);
     clearSlotPanels();
-    if (state.currentPage === 1 && state.currentType === "web") {
+    const isImageType = isImageSearchType(state.currentType);
+    if (state.currentPage === 1 && !isImageType) {
       void fetchGlancePanels(state.currentQuery, data.results);
     }
-    if (state.currentType === "web") {
+    if (!isImageType) {
       void fetchSlotPanels(state.currentQuery, state.currentResults);
     }
     renderResults(state.currentResults);

--- a/src/client/utils/search/search-actions-render.ts
+++ b/src/client/utils/search/search-actions-render.ts
@@ -90,7 +90,7 @@ export const prepareResultsUi = (query: string, resolvedType: string): void => {
   if (isImageType) {
     abortGlancePanels();
     abortSlotPanels();
-  } else if (resolvedType === "web") {
+  } else {
     void fetchSlotPanels(query).then((panels) => {
       const kp = panels.filter((p) => p.position === SlotPanelPosition.KnowledgePanel);
       if (kp.length > 0) prependKnowledgePanels(kp);
@@ -98,8 +98,7 @@ export const prepareResultsUi = (query: string, resolvedType: string): void => {
     void fetchGlancePanels(query);
   }
   const glanceEl = document.getElementById("at-a-glance");
-  if (glanceEl)
-    glanceEl.innerHTML = resolvedType === "web" ? skeletonGlance() : "";
+  if (glanceEl) glanceEl.innerHTML = isImageType ? "" : skeletonGlance();
   const resultsList = document.getElementById("results-list");
   if (resultsList) {
     resultsList.innerHTML = isImageType
@@ -171,7 +170,7 @@ export const renderSearchResponse = (
     if (glanceEl) glanceEl.innerHTML = "";
     renderImgEngines(data.engineTimings ?? []);
     if (sidebar) sidebar.innerHTML = "";
-  } else if (type === "web") {
+  } else {
     if (opts.fetchGlance) void fetchGlancePanels(query, data.results);
     void fetchSlotPanels(query, data.results).then((panels) => {
       const kpPanels = panels.filter(
@@ -183,9 +182,6 @@ export const renderSearchResponse = (
         kpPanels.length > 0 ? { sidebarTopPanels: kpPanels } : undefined,
       );
     });
-  } else {
-    renderSidebar(data, navigate);
-    if (glanceEl) glanceEl.innerHTML = "";
   }
   const infinite = infiniteScrollOn() && !isImageType;
   renderResults(data.results, { paginate: !infinite });

--- a/src/client/utils/streaming-search.ts
+++ b/src/client/utils/streaming-search.ts
@@ -157,7 +157,7 @@ export async function performStreamingSearch(
   if (isImageType) {
     abortGlancePanels();
     abortSlotPanels();
-  } else if (type === "web") {
+  } else {
     void fetchSlotPanels(query).then((panels) => {
       const kp = panels.filter((p) => p.position === SlotPanelPosition.KnowledgePanel);
       if (kp.length > 0) prependKnowledgePanels(kp);
@@ -165,7 +165,7 @@ export async function performStreamingSearch(
     void fetchGlancePanels(query);
   }
   const glanceEl = document.getElementById("at-a-glance");
-  if (glanceEl) glanceEl.innerHTML = type === "web" ? skeletonGlance() : "";
+  if (glanceEl) glanceEl.innerHTML = isImageType ? "" : skeletonGlance();
   document.title = `${query} - degoog`;
 
   const urlParams = new URLSearchParams({ q: query });
@@ -302,7 +302,7 @@ export async function performStreamingSearch(
       renderImgEngines(data.engineTimings);
       if (sidebar) sidebar.innerHTML = "";
       if (currentResults.length > 0) setupMediaObserver("images");
-    } else if (type === "web") {
+    } else {
       updateEngineTimings(sidebar, data.engineTimings);
       void fetchGlancePanels(query, currentResults);
       void fetchSlotPanels(query, currentResults).then((panels) => {
@@ -315,10 +315,6 @@ export async function performStreamingSearch(
           kpPanels.length > 0 ? { sidebarTopPanels: kpPanels } : undefined,
         );
       });
-    } else {
-      updateEngineTimings(sidebar, data.engineTimings);
-      renderSidebar(searchData, (q) => onComplete(q));
-      if (glanceEl) glanceEl.innerHTML = "";
     }
 
     if (currentResults.length === 0 && resultsList) {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -620,6 +620,10 @@
       "slot-position": {
         "label": "Position",
         "description": "Where the slot content appears on the page."
+      },
+      "slot-search-types": {
+        "label": "Search types",
+        "description": "Which result tabs this slot renders on. Images are not supported."
       }
     },
     "shortcuts": {

--- a/src/server/extensions/slots/registry.ts
+++ b/src/server/extensions/slots/registry.ts
@@ -3,6 +3,7 @@ import {
   ExtensionStoreType,
   SlotPanelPosition,
   SLOT_POSITION_SETTING_KEY,
+  SLOT_SEARCH_TYPES_KEY,
   type ExtensionMeta,
   type SettingField,
   type SlotPlugin,
@@ -22,6 +23,9 @@ import { bootCircuitFromPath } from "../../utils/translation-circuit";
 import { createRegistry } from "../registry-factory";
 import { getInterceptors } from "../interceptors/registry";
 import { isPluginManifest } from "../plugin-manifest";
+import { getInstalledSearchTypes } from "../engines/registry";
+import { baseSlotTypes } from "../../utils/slot-types";
+import { parseTypeList } from "../../../shared/search-types";
 import { isExtensionRestartFlagVisible } from "../../utils/restart-state";
 
 const builtinsDir = join(
@@ -134,6 +138,7 @@ export const getSlotExtensionMeta = async (
 ): Promise<ExtensionMeta[]> => {
   const slots = getSlotPlugins();
   const out: ExtensionMeta[] = [];
+  const installedTypes = parseTypeList(await getInstalledSearchTypes());
 
   for (const slot of slots) {
     if (!slot.id) {
@@ -175,6 +180,25 @@ export const getSlotExtensionMeta = async (
       });
     }
 
+    const slotDefaults = baseSlotTypes(slot);
+    const typeOptions = [
+      ...new Set([...slotDefaults, ...installedTypes]),
+    ];
+
+    fullSchema.push({
+      key: SLOT_SEARCH_TYPES_KEY,
+      label: coreT
+        ? coreT("settings-page.schema.slot-search-types.label") || "Search types"
+        : "Search types",
+      type: "multiselect",
+      options: typeOptions,
+      default: slotDefaults.join(","),
+      description: coreT
+        ? coreT("settings-page.schema.slot-search-types.description") ||
+          "Which result tabs this slot renders on. Images are not supported."
+        : "Which result tabs this slot renders on. Images are not supported.",
+    });
+
     const id = slot.settingsId ?? slot.id;
     const raw = await getSettings(id);
     const settings = maskSecrets(raw, fullSchema);
@@ -190,6 +214,11 @@ export const getSlotExtensionMeta = async (
         ? value
         : slot.position;
     }
+
+    const storedTypes = parseTypeList(raw[SLOT_SEARCH_TYPES_KEY]);
+    settings[SLOT_SEARCH_TYPES_KEY] = (
+      storedTypes.length > 0 ? storedTypes : slotDefaults
+    ).filter((type) => typeOptions.includes(type));
 
     const { exists: docsExist } = await extensionReadmeExists(id);
 

--- a/src/server/routes/slots.ts
+++ b/src/server/routes/slots.ts
@@ -14,14 +14,19 @@ import { isDisabled } from "../utils/plugin-settings";
 import { buildSignedProxyUrl } from "../utils/proxy-sign";
 import { getClientIp } from "../utils/request";
 import { _applyRateLimit, runSlotPlugins } from "../utils/search";
+import { slotShowsOn } from "../utils/slot-types";
+import { DEFAULT_SEARCH_TYPE } from "../../shared/search-types";
 import { applyFilter, syncVortexSignal } from "../utils/translation-circuit";
 
 const router = new Hono();
 
+const _requestedType = (raw: unknown): string =>
+  typeof raw === "string" && raw.trim() ? raw.trim() : DEFAULT_SEARCH_TYPE;
+
 router.post("/api/slots", async (c) => {
   const limitRes = await _applyRateLimit(c);
   if (limitRes) return limitRes;
-  let body: { query?: string; results?: ScoredResult[] };
+  let body: { query?: string; type?: string; results?: ScoredResult[] };
   try {
     body = await c.req.json();
   } catch (err) {
@@ -41,6 +46,7 @@ router.post("/api/slots", async (c) => {
     {
       excludePosition: SlotPanelPosition.AtAGlance,
       locale: getLocale(c),
+      searchType: _requestedType(body.type),
     },
   );
   return c.json({ panels });
@@ -49,7 +55,7 @@ router.post("/api/slots", async (c) => {
 router.post("/api/slots/glance", async (c) => {
   const limitRes = await _applyRateLimit(c);
   if (limitRes) return limitRes;
-  let body: { query?: string; results?: ScoredResult[] };
+  let body: { query?: string; type?: string; results?: ScoredResult[] };
   try {
     body = await c.req.json();
   } catch (err) {
@@ -65,6 +71,7 @@ router.post("/api/slots/glance", async (c) => {
   }
   const clientIp = getClientIp(c);
   const locale = getLocale(c);
+  const searchType = _requestedType(body.type);
   const glancePlugins = getSlotPlugins().filter(
     (p) => p.position === SlotPanelPosition.AtAGlance,
   );
@@ -81,6 +88,7 @@ router.post("/api/slots/glance", async (c) => {
     try {
       const slotSettingsId = plugin.settingsId ?? `slot-${plugin.id}`;
       if (await isDisabled(slotSettingsId)) continue;
+      if (!(await slotShowsOn(plugin, slotSettingsId, searchType))) continue;
       const ok = await Promise.resolve(plugin.trigger(body.query!.trim()));
       if (!ok) continue;
       const context: SlotPluginContext = {

--- a/src/server/types/extension.ts
+++ b/src/server/types/extension.ts
@@ -72,6 +72,7 @@ export interface SettingField {
   | "toggle"
   | "textarea"
   | "select"
+  | "multiselect"
   | "urllist"
   | "list"
   | "hex"
@@ -192,6 +193,7 @@ export interface AutocompleteProvider {
 }
 
 export const SLOT_POSITION_SETTING_KEY = "slotPosition";
+export const SLOT_SEARCH_TYPES_KEY = "slotSearchTypes";
 
 export interface SlotPluginContext {
   clientIp?: string;
@@ -209,6 +211,7 @@ export interface SlotPlugin {
   description: string;
   position: SlotPanelPosition;
   slotPositions?: SlotPanelPosition[];
+  searchTypes?: string[];
   settingsId?: string;
   isClientExposed?: boolean;
   needsAppRestart?: boolean;

--- a/src/server/utils/search.ts
+++ b/src/server/utils/search.ts
@@ -22,6 +22,8 @@ import { getClientIp } from "./request";
 import { applyFilter, syncVortexSignal } from "./translation-circuit";
 import { getInstanceSettings } from "./server-settings";
 import { SLOT_PLUGIN_TIMEOUT_MS, withTimeout } from "./with-timeout";
+import { DEFAULT_SEARCH_TYPE } from "../../shared/search-types";
+import { slotShowsOn } from "./slot-types";
 
 export const DEFAULT_LANGUAGES = [
   "af",
@@ -144,12 +146,17 @@ export async function runSlotPlugins(
   query: string,
   clientIp?: string,
   results?: ScoredResult[],
-  options?: { excludePosition?: SlotPanelPosition; locale?: string },
+  options?: {
+    excludePosition?: SlotPanelPosition;
+    locale?: string;
+    searchType?: string;
+  },
 ): Promise<SlotPanel[]> {
   const plugins = getSlotPlugins();
   const panels: SlotPanel[] = [];
   const exclude = options?.excludePosition;
   const locale = options?.locale;
+  const searchType = options?.searchType ?? DEFAULT_SEARCH_TYPE;
   for (const plugin of plugins) {
     if (!plugin.id) {
       logger.warn(
@@ -172,6 +179,7 @@ export async function runSlotPlugins(
       }
     }
     if (exclude && definedPosition === exclude) continue;
+    if (!(await slotShowsOn(plugin, slotSettingsId, searchType))) continue;
     const withResults = results !== undefined;
     if (withResults && !plugin.waitForResults) continue;
     if (!withResults && plugin.waitForResults) continue;

--- a/src/server/utils/slot-types.ts
+++ b/src/server/utils/slot-types.ts
@@ -1,0 +1,27 @@
+import {
+  DEFAULT_SEARCH_TYPE,
+  parseTypeList,
+  slotRunsOn,
+} from "../../shared/search-types";
+import { SLOT_SEARCH_TYPES_KEY, type SlotPlugin } from "../types";
+import { getSettings } from "./plugin-settings";
+
+export const baseSlotTypes = (slot: SlotPlugin): string[] => {
+  const declared = parseTypeList(slot.searchTypes);
+  return declared.length > 0 ? declared : [DEFAULT_SEARCH_TYPE];
+};
+
+export const slotTypes = async (
+  slot: SlotPlugin,
+  settingsId: string,
+): Promise<string[]> => {
+  const raw = await getSettings(settingsId);
+  const chosen = parseTypeList(raw[SLOT_SEARCH_TYPES_KEY]);
+  return chosen.length > 0 ? chosen : baseSlotTypes(slot);
+};
+
+export const slotShowsOn = async (
+  slot: SlotPlugin,
+  settingsId: string,
+  type: string,
+): Promise<boolean> => slotRunsOn(await slotTypes(slot, settingsId), type);

--- a/src/shared/search-types.ts
+++ b/src/shared/search-types.ts
@@ -61,3 +61,40 @@ export interface SearchResponse {
   slotPanels?: SlotPanel[];
   totalPages?: number;
 }
+
+export const DEFAULT_SEARCH_TYPE = "web";
+export const IMAGE_SEARCH_TYPE = "images";
+
+const TAB_ENGINE_PREFIX = "tab:engine:";
+const ENGINE_PREFIX = "engine:";
+
+export const resolveBuiltinSearchType = (type: string): string => {
+  if (type.startsWith(TAB_ENGINE_PREFIX)) {
+    return type.slice(TAB_ENGINE_PREFIX.length);
+  }
+  if (type.startsWith(ENGINE_PREFIX)) return type.slice(ENGINE_PREFIX.length);
+  return type;
+};
+
+export const isImageSearchType = (type: string): boolean =>
+  resolveBuiltinSearchType(type) === IMAGE_SEARCH_TYPE;
+
+export const parseTypeList = (
+  raw: string | string[] | boolean | undefined,
+): string[] => {
+  const entries = Array.isArray(raw)
+    ? raw
+    : typeof raw === "string"
+      ? raw.split(",")
+      : [];
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const type = String(entry).trim();
+    if (type && type !== IMAGE_SEARCH_TYPE) seen.add(type);
+  }
+  return [...seen];
+};
+
+export const slotRunsOn = (allowed: string[], type: string): boolean =>
+  !isImageSearchType(type) &&
+  allowed.includes(resolveBuiltinSearchType(type) || DEFAULT_SEARCH_TYPE);

--- a/src/styles/components/overrides/_extension-cards.scss
+++ b/src/styles/components/overrides/_extension-cards.scss
@@ -472,6 +472,38 @@
   }
 }
 
+.ext-field-multiselect {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $space-2;
+
+  &-chip {
+    background: var(--bg-hover);
+    border: none;
+    border-radius: $radius-pill;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: $font-size-small;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    padding: $space-2 $space-4;
+
+    &:hover {
+      color: var(--text-primary);
+    }
+
+    &--on {
+      background: $primary;
+      color: var(--bg);
+
+      &:hover {
+        background: $primary-hover;
+        color: var(--bg);
+      }
+    }
+  }
+}
+
 .ext-field-hex {
   display: flex;
   align-items: center;

--- a/tests/slots/search-types.test.ts
+++ b/tests/slots/search-types.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_SEARCH_TYPE,
+  parseTypeList,
+  slotRunsOn,
+} from "../../src/shared/search-types";
+import { baseSlotTypes } from "../../src/server/utils/slot-types";
+import { SlotPanelPosition, type SlotPlugin } from "../../src/server/types";
+
+const makeSlot = (searchTypes?: string[]): SlotPlugin => ({
+  name: "test",
+  description: "test",
+  position: SlotPanelPosition.KnowledgePanel,
+  searchTypes,
+  trigger: () => true,
+  execute: async () => ({ html: "<p>hi</p>" }),
+});
+
+describe("parseTypeList", () => {
+  test("splits a comma string and trims entries", () => {
+    expect(parseTypeList("web, news ,videos")).toEqual([
+      "web",
+      "news",
+      "videos",
+    ]);
+  });
+
+  test("accepts an array and drops blanks and duplicates", () => {
+    expect(parseTypeList(["web", "", "news", "web"])).toEqual(["web", "news"]);
+  });
+
+  test("drops images because slots cannot render in media mode", () => {
+    expect(parseTypeList(["web", "images"])).toEqual(["web"]);
+    expect(parseTypeList("images")).toEqual([]);
+  });
+
+  test("returns empty for unset or boolean values", () => {
+    expect(parseTypeList(undefined)).toEqual([]);
+    expect(parseTypeList(true)).toEqual([]);
+  });
+});
+
+describe("slotRunsOn", () => {
+  test("matches a plain type", () => {
+    expect(slotRunsOn(["web", "news"], "news")).toBe(true);
+    expect(slotRunsOn(["web"], "news")).toBe(false);
+  });
+
+  test("resolves engine tab prefixes to the underlying type", () => {
+    expect(slotRunsOn(["news"], "tab:engine:news")).toBe(true);
+    expect(slotRunsOn(["news"], "engine:news")).toBe(true);
+  });
+
+  test("never runs on images even when listed", () => {
+    expect(slotRunsOn(["images"], "images")).toBe(false);
+    expect(slotRunsOn(["web", "images"], "tab:engine:images")).toBe(false);
+  });
+});
+
+describe("baseSlotTypes", () => {
+  test("defaults to web when the slot declares nothing", () => {
+    expect(baseSlotTypes(makeSlot())).toEqual([DEFAULT_SEARCH_TYPE]);
+    expect(baseSlotTypes(makeSlot([]))).toEqual([DEFAULT_SEARCH_TYPE]);
+  });
+
+  test("honours declared types", () => {
+    expect(baseSlotTypes(makeSlot(["news", "videos"]))).toEqual([
+      "news",
+      "videos",
+    ]);
+  });
+
+  test("falls back to web when a slot only declares images", () => {
+    expect(baseSlotTypes(makeSlot(["images"]))).toEqual([DEFAULT_SEARCH_TYPE]);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multiselect controls to extension settings with selectable chips.
  * Slot extensions can now be configured for specific search types.
  * Search result panels and glance content now load across non-image search types.
  * Added localized labels and descriptions for slot search-type configuration.

* **Bug Fixes**
  * Slot requests now respect the active search type.
  * Slots are filtered appropriately by search type, while image searches remain excluded.
  * Explicitly empty slot search-type selections are now preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->